### PR TITLE
fix:handle_bad_default_persona_cfg

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -148,8 +148,9 @@ class PersonaService(PipelineStageConfidenceMatcher, OVOSAbstractApplication):
 
     def get_persona(self, persona: str):
         if not persona:
-            return self.active_persona or self.default_persona
+            return self.active_persona or self.get_persona(self.default_persona)
         # TODO - add ignorecase flag to match_one in ovos_utils
+        # TODO - make MatchStrategy configurable
         match, score = match_one(persona, list(self.personas),
                                  strategy=MatchStrategy.PARTIAL_TOKEN_SET_RATIO)
         LOG.debug(f"Closest persona: {match} - {score}")
@@ -336,8 +337,14 @@ class PersonaService(PipelineStageConfidenceMatcher, OVOSAbstractApplication):
         Returns:
             IntentMatch if handled otherwise None.
         """
+        persona = self.active_persona
+        if self.config.get("handle_fallback"):
+            # read default persona from config
+            persona = persona or self.get_persona(self.default_persona)
+            if not persona:
+                LOG.error("configured default persona is invalid, can't handle utterance")
         # always matches! use as last resort in pipeline
-        if self.active_persona or self.config.get("handle_fallback"):
+        if persona:
             return IntentHandlerMatch(match_type='persona:query',
                                       match_data={"utterance": utterances[0],
                                                   "lang": lang,

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -142,13 +142,15 @@ class PersonaService(PipelineStageConfidenceMatcher, OVOSAbstractApplication):
     @property
     def default_persona(self) -> Optional[str]:
         persona = self.config.get("default_persona")
-        if not persona and self.personas:
+        if persona: # match config against loaded personas
+            persona = self.get_persona(persona)
+        elif self.personas:
             persona = list(self.personas.keys())[0]
         return persona
 
     def get_persona(self, persona: str):
         if not persona:
-            return self.active_persona or self.get_persona(self.default_persona)
+            return self.active_persona or self.default_persona
         # TODO - add ignorecase flag to match_one in ovos_utils
         # TODO - make MatchStrategy configurable
         match, score = match_one(persona, list(self.personas),

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -342,7 +342,7 @@ class PersonaService(PipelineStageConfidenceMatcher, OVOSAbstractApplication):
         persona = self.active_persona
         if self.config.get("handle_fallback"):
             # read default persona from config
-            persona = persona or self.get_persona(self.default_persona)
+            persona = persona or self.default_persona
             if not persona:
                 LOG.error("configured default persona is invalid, can't handle utterance")
         # always matches! use as last resort in pipeline


### PR DESCRIPTION
dont match_low if default persona in config is invalid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced the assistant’s persona management for more reliable default selection based on your configuration settings.
	- Improved the matching and fallback behavior to ensure a consistent and accurate persona is applied even when an invalid setting is encountered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->