### PR TITLE
fix: lowercase

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -163,9 +163,8 @@ class PersonaService(PipelineStageConfidenceMatcher, OVOSAbstractApplication):
         # TODO - add ignorecase flag to match_one in ovos_utils
         lc = {p.lower(): p for p in self.personas}
         # TODO - make MatchStrategy configurable
-        match, score = match_one(persona.lower(), list(lc),
+        match, score = match_one(persona.lower(), lc,
                                  strategy=MatchStrategy.PARTIAL_TOKEN_SET_RATIO)
-        match = lc[match] # retrieve original string
         LOG.debug(f"Closest persona: {match} - {score}")
         return match if score >= 0.7 else None
 

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -161,9 +161,11 @@ class PersonaService(PipelineStageConfidenceMatcher, OVOSAbstractApplication):
         if not persona:
             return self.active_persona or self.default_persona
         # TODO - add ignorecase flag to match_one in ovos_utils
+        lc = {p.lower(): p for p in self.personas}
         # TODO - make MatchStrategy configurable
-        match, score = match_one(persona.lower(), [p.lower() for p in self.personas],
+        match, score = match_one(persona.lower(), list(lc),
                                  strategy=MatchStrategy.PARTIAL_TOKEN_SET_RATIO)
+        match = lc[match] # retrieve original string
         LOG.debug(f"Closest persona: {match} - {score}")
         return match if score >= 0.7 else None
 


### PR DESCRIPTION
#102 continued

need to return original string not lowercased

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persona name matching to preserve original casing when selecting a persona, ensuring consistent display of persona names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->