### PR TITLE
feat: persona per session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.0a2](https://github.com/OpenVoiceOS/ovos-persona/tree/0.8.0a2) (2026-06-13)
+
+[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.8.0a1...0.8.0a2)
+
+**Merged pull requests:**
+
+- chore: drop gitlocalize translations/ + sync script + scratch noise [\#166](https://github.com/OpenVoiceOS/ovos-persona/pull/166) ([JarbasAl](https://github.com/JarbasAl))
+
 ## [0.8.0a1](https://github.com/OpenVoiceOS/ovos-persona/tree/0.8.0a1) (2026-06-13)
 
 [Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.5a2...0.8.0a1)
@@ -19,7 +27,7 @@
 
 ## [0.7.5a1](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.5a1) (2026-06-05)
 
-[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a5...0.7.5a1)
+[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a3...0.7.5a1)
 
 **Merged pull requests:**
 
@@ -27,17 +35,17 @@
 - fix\(i18n\): normalize locale folders to canonical BCP-47 [\#158](https://github.com/OpenVoiceOS/ovos-persona/pull/158) ([JarbasAl](https://github.com/JarbasAl))
 - Change 'persona' to 'system\_prompt' in README [\#157](https://github.com/OpenVoiceOS/ovos-persona/pull/157) ([denics](https://github.com/denics))
 
-## [0.7.4a5](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.4a5) (2026-03-29)
+## [0.7.4a3](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.4a3) (2026-03-29)
 
-[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a4...0.7.4a5)
+[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a4...0.7.4a3)
 
 ## [0.7.4a4](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.4a4) (2026-03-29)
 
-[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a3...0.7.4a4)
+[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a5...0.7.4a4)
 
-## [0.7.4a3](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.4a3) (2026-03-29)
+## [0.7.4a5](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.4a5) (2026-03-29)
 
-[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a2...0.7.4a3)
+[Full Changelog](https://github.com/OpenVoiceOS/ovos-persona/compare/0.7.4a2...0.7.4a5)
 
 ## [0.7.4a2](https://github.com/OpenVoiceOS/ovos-persona/tree/0.7.4a2) (2026-03-29)
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The **`PersonaPipeline`** brings multi-persona management to OpenVoiceOS (OVOS),
 
 - **🧑‍💻 Multiple Personas**: Manage a list of personas, each with its unique solvers.  
 - **🔄 Dynamic Switching**: Seamlessly switch between personas as needed.  
+- **🧵 Per-session state**: The active persona and conversation memory are tracked **per session**, so concurrent conversations stay isolated.  
+- **🧠 Short-term memory**: A default short-term memory ships with ovos-persona and is **always available** (per-session history); swap it for any `opm.agents.memory` plugin via `memory_module`. See [`docs/memory.md`](docs/memory.md).  
 - **💬 Conversational**: Let personas handle utterances directly for richer interaction.  
 - **🎨 Personalize**: Create your own personas with simple `.json` files.
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -82,3 +82,19 @@ context = memory.build_conversation_context("what is the capital of France?", "s
 | `build_conversation_context(utterance, session_id)` | Produce the full message list for a solver query |
 
 Install a third-party plugin and set `memory_module` in the persona config to its entry point name to use it.
+
+---
+
+## Default plugin & per-session isolation
+
+`BasicShortTermMemory` is **shipped and registered by ovos-persona itself** as the
+entry point `ovos-agents-short-term-memory-plugin` (group `opm.agents.memory`), so a
+default short-term memory is **always available** — no extra package required. Every
+`Persona` loads it automatically unless `memory_module` is set to another plugin (or
+to a falsy value to disable memory). If a configured `memory_module` is unavailable,
+the persona degrades gracefully with memory disabled rather than failing to load.
+
+History is **isolated per session**: all storage and retrieval are keyed by
+`session_id` (`session2history[session_id]`), so concurrent conversations on different
+sessions never see each other's context. With per-session active personas, each
+session's turns are recorded against the persona active *for that session*.

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -49,11 +49,13 @@ class Persona:
         self.config = config
 
         memory_plugin = self.config.get("memory_module", "ovos-agents-short-term-memory-plugin")
-        if memory_plugin:
-            memory_class = load_memory_plugin(memory_plugin)
-            self.memory = memory_class()
-        else:
+        memory_class = load_memory_plugin(memory_plugin) if memory_plugin else None
+        if memory_class is None:
+            if memory_plugin:
+                LOG.warning(f"memory plugin '{memory_plugin}' not available; short-term memory disabled")
             self.memory = None
+        else:
+            self.memory = memory_class()
 
         plugin_order = config.get("handlers") or config.get("solvers") or []
         if not plugin_order:
@@ -89,29 +91,29 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
                  config: Optional[Dict] = None):
         """
-        Initialize the PersonaService, load configured personas and intent matchers, and register message-bus event handlers.
-        
+        Create and initialize the PersonaService, load personas and intent matchers, and register message-bus handlers.
+         
         Parameters:
-            bus (Optional[MessageBusClient | FakeBus]): Message bus client to use for events and IPC. If omitted, a local FakeBus is created.
-            config (Optional[dict]): Persona-specific configuration; when omitted the service reads the "intents.persona" section from global Configuration.
-        
-        Side effects:
+            bus (Optional[MessageBusClient | FakeBus]): Message bus client used for events and IPC. If omitted, a local FakeBus is created.
+            config (Optional[dict]): Persona-specific configuration. If omitted, the service reads the "intents.persona" section from global Configuration.
+         
+        Behavior:
             - Initializes base application and confidence-matching pipeline.
-            - Loads personas from configured paths and plugin sources.
-            - Registers intent-related and session event handlers on the bus.
+            - Loads personas from configured paths and plugin providers.
             - Loads per-language intent matcher files.
-            - Initializes runtime attributes: `sessions`, `personas`, `intent_matchers`, `blacklist`, `active_persona`, and `_active_sessions`.
+            - Registers message-bus event handlers for persona operations and utterance/speak events.
+            - Initializes runtime state: `message_history` (per-session history), `active_personas` (per-session active persona), `personas`, `intent_matchers`, `blacklist`, and `_active_sessions`.
         """
         bus = bus or FakeBus()
         config = config or Configuration().get("intents", {}).get("persona", {})
         OVOSAbstractApplication.__init__(self, bus=bus, skill_id="persona.openvoiceos",
                                          resources_dir=f"{dirname(__file__)}")
         ConfidenceMatcherPipeline.__init__(self, bus=bus, config=config)
+        self.active_personas = {}  # per session_id
         self.personas = {}
         self.intent_matchers = {}
         self.blacklist = self.config.get("persona_blacklist") or []
         self.load_personas(self.config.get("personas_path"))
-        self.active_persona = None
         # is_intent flag ensures "ovos.utterance.handled" is emitted
         self.add_event('persona:query', self.handle_persona_query, is_intent=True)
         self.add_event('persona:summon', self.handle_persona_summon, is_intent=True)
@@ -126,12 +128,12 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     @classmethod
     def load_resource_files(cls):
         """
-        Build a mapping of language tags to intent sample lists loaded from the package locale files.
+        Load intent sample texts from this package's locale resources for configured languages.
         
-        For each configured language (secondary_langs plus the primary lang), finds the locale directory for that language and, for each file whose name matches an entry in cls.INTENTS, reads the file as newline-separated intent samples. Each sample has doubled braces `{{` / `}}` collapsed to single `{` / `}`. Languages or intent files that are not present are skipped.
+        For each language in Configuration().get('secondary_langs') plus the primary language (Configuration().get('lang')), locate the package locale directory for that language and collect files whose names match entries in cls.INTENTS. Each matching file is read as newline-separated samples; doubled braces `{{` / `}}` in samples are collapsed to single `{` / `}`. Missing languages or intent files are skipped.
         
         Returns:
-            dict: A mapping {language_tag: {intent_name: [sample_str, ...], ...}, ...} containing loaded intent samples per language.
+            dict: Mapping from language tag to a dict of intent name -> list of sample strings, i.e. {language: {intent_name: [sample, ...], ...}, ...}.
         """
         intents = {}
         langs = Configuration().get('secondary_langs', []) + [Configuration().get('lang', "en-US")]
@@ -154,9 +156,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         # TODO - make intent backend configurable, padatious is not a good choice...
         """
         Load and prepare intent matchers for each configured language and register persona intent samples.
-        
+
         Builds a per-language IntentContainer (using a cache directory when applicable), registers intent samples sourced from locale/resource files, and trains or instantiates matchers when the configured backend requires it. Skips training for known problematic language/intent combinations and logs failures for individual intent registrations.
-        
+
         Side effects:
         - Populates and updates self.intent_matchers with initialized IntentContainer instances keyed by language tag.
         - Reads intent samples via self.load_resource_files().
@@ -189,21 +191,63 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     @property
     def default_persona(self) -> Optional[str]:
+        """
+        Determine the default persona name for this service.
+        
+        If a `default_persona` is configured, returns the best-matching loaded persona name. If no configuration is present but personas are loaded, returns the first loaded persona name. Returns `None` when no persona can be resolved.
+        
+        Returns:
+            Optional[str]: The resolved persona name, or `None` if no personas are available.
+        """
         persona = self.config.get("default_persona")
         if persona: # match config against loaded personas
-            persona = self.get_persona(persona)
+            persona = self.match_persona(persona)
         elif self.personas:
             persona = list(self.personas.keys())[0]
         return persona
 
-    def get_persona(self, persona: str):
+    def get_active_persona(self, message, include_default=True) -> Optional[str]:
         """
-        Finds the closest matching persona name to the given input using case-insensitive partial token set matching.
+        Determine the active persona for the given message/session following priority rules.
         
-        If no input is provided, returns the currently active persona or the default persona. Returns the matched persona name if the similarity score is at least 0.7; otherwise, returns None.
+        Checks, in order: an explicitly requested persona in message.data, a session-scoped active persona, the session's default persona (if include_default), and the configured default persona (if include_default).
+        
+        Parameters:
+            message: The incoming message object containing session/context data.
+            include_default (bool): If True, allow falling back to the session or configured default persona.
+        
+        Returns:
+            Optional[str]: The resolved persona name if one is found, `None` otherwise.
+        """
+        sess = SessionManager.get(message)
+        # prioritize explicitly requested persona via message.data (eg, summon intent)
+        if message and message.data.get("persona"):
+            persona = self.match_persona(message.data.get("persona"))
+            if persona:
+                return persona
+        # check if a persona is active
+        if sess.session_id in self.active_personas:
+            return self.active_personas[sess.session_id]
+        # default persona from Session
+        elif sess.persona_id and include_default:
+            return sess.persona_id
+        # default persona from config
+        elif self.default_persona and include_default:
+            return self.default_persona
+        return None
+
+    def match_persona(self, persona: str):
+        """
+        Finds the registered persona name that best matches the given input using case-insensitive partial token-set fuzzy matching.
+        
+        Parameters:
+            persona (str): Candidate persona name or phrase to match against registered personas.
+        
+        Returns:
+            str or None: The matched persona name if the similarity score is at least 0.7, `None` if the input is empty or no persona meets the threshold.
         """
         if not persona:
-            return self.active_persona or self.default_persona
+            return None
         # TODO - make MatchStrategy configurable
         match, score = match_one(persona, list(self.personas),
                                  strategy=MatchStrategy.PARTIAL_TOKEN_SET_RATIO, 
@@ -213,9 +257,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     def load_personas(self, personas_path: Optional[str] = None):
         """
-        Load persona definitions from the filesystem and (unless disabled) plugin providers and register them on this service.
+        Discover and register persona definitions from disk and from installed persona plugins into this service.
         
-        Searches the given directory for JSON files and creates Persona instances for each file found, skipping any names in self.blacklist. If a JSON file provides a "name" field it is used as the persona name. Errors while loading individual persona files are logged and do not stop processing. Unless the configuration key "ignore_plugin_personas" is true, the method also queries installed persona plugins and registers those personas, skipping blacklisted names and any persona already loaded from disk.
+        Scans the provided directory for JSON files (or the XDG config path if None), creates Persona instances for each file found, and registers them under their filename or the JSON's "name" field. Skips personas present in self.blacklist. Errors while loading individual persona files are logged and do not stop processing. Unless the configuration key "ignore_plugin_personas" is true, also loads persona definitions discovered from installed plugin providers, skipping blacklisted names and any persona already loaded from disk.
         
         Parameters:
             personas_path (Optional[str]): Directory to read user-defined persona JSON files from. If None, the XDG config path for "ovos_persona" is used.
@@ -243,7 +287,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         # load personas provided by packages
         if self.config.get("ignore_plugin_personas", False):
             return
-            
+
         for name, persona in find_persona_plugins().items():
             if name in self.blacklist:
                 continue
@@ -257,10 +301,23 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 LOG.error(f"Failed to load '{name}': {e}")
 
     def register_persona(self, name, persona):
+        """
+        Register or update a persona under the given name using the provided configuration.
+        
+        Parameters:
+            name (str): Identifier for the persona.
+            persona (dict): Persona configuration dictionary used to construct the Persona instance.
+        """
         self.personas[name] = Persona(name, persona)
 
     def deregister_persona(self, name):
-        name = self.get_persona(name) or ""
+        """
+        Deregister a persona by name, removing it from the service's registry if found.
+        
+        Parameters:
+            name (str): Exact or partial persona name to remove; the input will be resolved to a registered persona (fuzzy/case-insensitive match) before removal.
+        """
+        name = self.match_persona(name) or ""
         if name in self.personas:
             self.personas.pop(name)
 
@@ -275,22 +332,32 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def match_high(self, utterances: List[str], lang: Optional[str] = None,
                    message: Optional[Message] = None) -> Optional[IntentHandlerMatch]:
         """
-        Recommended before common query
-
-        Args:
-            utterances (list):  list of utterances
-            lang (string):      4 letter ISO language code
-            message (Message):  message to use to generate reply
-
+        High-priority intent matcher for persona-related utterances.
+       
+        Analyzes the first utterance (language-normalized) for persona control and query intents. It:
+        - Detects a release intent when a session has an active persona and returns a 'persona:release' match.
+        - Uses per-language intent matchers to identify persona intents (summon, list, active_persona, ask).
+        - Applies the configured minimum intent confidence threshold before accepting a match.
+        - For 'summon.intent', returns a 'persona:summon' match when a persona entity is present.
+        - For 'list_personas.intent', returns a 'persona:list' match.
+        - For 'active_persona.intent', returns a 'persona:check' match.
+        - For 'ask.intent', requires both persona and utterance entities and verifies the persona against registered personas via match_persona; returns a 'persona:query' match when verified.
+        - If an active persona exists and no explicit persona intent is accepted, delegates to the low-priority matcher to allow persona-scoped handling.
+       
+        Parameters:
+            utterances (List[str]): Candidate user utterances; only the first entry is used for matching.
+            lang (Optional[str]): Language tag to use for intent matching; will be standardized if provided.
+            message (Optional[Message]): Message object providing session/context (used to detect session active persona).
+       
         Returns:
-            IntentMatch if handled otherwise None.
+            IntentHandlerMatch or None: An IntentHandlerMatch for handled persona intents (`persona:release`, `persona:summon`, `persona:list`, `persona:check`, `persona:query`) or `None` if no high-priority persona intent was matched.
         """
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
-
-        if self.active_persona and self.voc_match(utterances[0], "Release", lang):
+        active_persona = self.get_active_persona(message, include_default=False)
+        if active_persona and self.voc_match(utterances[0], "Release", lang):
             return IntentHandlerMatch(match_type='persona:release',
-                                      match_data={"persona": self.active_persona},
+                                      match_data={"persona": active_persona},
                                       skill_id="persona.openvoiceos",
                                       utterance=utterances[0])
 
@@ -326,7 +393,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                                               utterance=utterances[0])
                 elif name == "ask.intent" and persona and query:
                     # if persona name or query not in match, its a misclassification
-                    persona = self.get_persona(persona)
+                    persona = self.match_persona(persona)
                     if persona: # name in intent must match a registered persona
                         return IntentHandlerMatch(match_type='persona:query',
                                                   match_data={"utterance": query,
@@ -339,17 +406,31 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                         # TODO - consider matching and reprompting user
 
             # override regular intent parsing, handle utterance until persona is released
-            if self.active_persona:
-                LOG.debug(f"Persona is active: {self.active_persona}")
+            if active_persona:
+                LOG.debug(f"Persona is active: {active_persona}")
                 return self.match_low(utterances, lang, message)
 
     def match_medium(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
+        """
+        Attempt medium-priority intent matching for persona-related utterances and return a corresponding IntentHandlerMatch when detected.
+        
+        Normalizes the language tag and checks, in order: (1) if a session has an active persona and the utterance matches a "Release" vocabulary, return a 'persona:release' match; (2) perform an adapt-like heuristic for queries that mention a known persona name and match "ask" + "opinion" or "summon" vocabularies, returning a 'persona:query' or 'persona:summon' match with extracted persona and query data. Matches use the closest supported language available and require both a resolved persona and query where applicable; misclassifications are ignored.
+        
+        Parameters:
+            utterances (List[str]): Candidate utterances (first element is used as the primary input).
+            lang (str): Requested language tag or None to use the service default.
+            message (Message): The incoming message object (used to resolve session-specific active persona).
+        
+        Returns:
+            IntentHandlerMatch or None: An IntentHandlerMatch for 'persona:release', 'persona:summon', or 'persona:query' when a medium-priority persona intent is found, otherwise None.
+        """
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
 
-        if self.active_persona and self.voc_match(utterances[0], "Release", lang):
+        active_persona = self.get_active_persona(message, include_default=False)
+        if active_persona and self.voc_match(utterances[0], "Release", lang):
             return IntentHandlerMatch(match_type='persona:release',
-                                      match_data={"persona": self.active_persona},
+                                      match_data={"persona": active_persona},
                                       skill_id="persona.openvoiceos",
                                       utterance=utterances[0])
 
@@ -396,7 +477,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                                               skill_id="persona.openvoiceos",
                                               utterance=utterances[0])
                 elif name == "ask.intent" and persona:  # if persona name not in match, its a misclassification
-                    persona = self.get_persona(persona)
+                    persona = self.match_persona(persona)
                     if persona and query:  # else its a misclassification
                         utterance = match["entities"].pop("query")
                         return IntentHandlerMatch(match_type='persona:query',
@@ -409,61 +490,96 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def match_low(self, utterances: List[str], lang: Optional[str] = None,
                   message: Optional[Message] = None) -> Optional[IntentHandlerMatch]:
         """
-        Recommended before fallback low
-
-        Args:
-            utterances (list):  list of utterances
-            lang (string):      4 letter ISO language code
-            message (Message):  message to use to generate reply
-
+        Attempt a final fallback match that routes the first utterance to an active or default persona.
+          
+        If a higher-priority medium match is found, it is returned. Otherwise, this method resolves the session's active persona (or the configured default when allowed) and constructs an IntentHandlerMatch of type "persona:query" containing the first utterance, language, and resolved persona. This match is intended as the last-resort handler in the matching pipeline and only produced when a persona is available (and fallback handling is enabled when necessary).
+          
+        Parameters:
+            utterances (List[str]): Candidate utterances (first element is used for the fallback query).
+            lang (Optional[str]): Language tag (e.g., "en-US") used for context resolution.
+            message (Optional[Message]): Optional message object used to resolve session-specific active persona.
+          
         Returns:
-            IntentMatch if handled otherwise None.
+            Optional[IntentHandlerMatch]: An IntentHandlerMatch of type "persona:query" when a fallback persona is resolved, `None` if no persona match or fallback is applicable.
         """
         match = self.match_medium(utterances, lang, message)
         if match:
             return match
 
-        persona = self.active_persona
-        if self.config.get("handle_fallback"):
-            # read default persona from config
-            persona = persona or self.default_persona
+        persona = self.get_active_persona(message, include_default=False)
+        if not persona and self.config.get("handle_fallback"):
+            # read default persona from session/config
+            persona = self.get_active_persona(message, include_default=True)
             if not persona:
                 LOG.error("configured default persona is invalid, can't handle utterance")
+
         # always matches! use as last resort in pipeline
         if persona:
             return IntentHandlerMatch(match_type='persona:query',
                                       match_data={"utterance": utterances[0],
                                                   "lang": lang,
-                                                  "persona": self.active_persona or self.default_persona},
+                                                  "persona": persona},
                                       skill_id="persona.openvoiceos",
                                       utterance=utterances[0])
 
     # bus events
     def handle_utterance(self, message):
+        """
+        Store the incoming user utterance in the per-session message history.
+        
+        Parameters:
+            message: Bus message object containing a `data` dict with an `utterances` list.
+                The first element of that list is taken as the user utterance. The session
+                is resolved via SessionManager.get(message); its `session_id` is used as
+                the key in `self.message_history`.
+        
+        Side effects:
+            Appends a tuple `("user", utterance)` to `self.message_history[session_id]`.
+        """
         utt = message.data.get("utterances")[0]
         sess = SessionManager.get(message)
-        persona_id: str = self.active_persona or self.default_persona
-        persona: Persona = self.personas[persona_id]
-        if persona.memory:
+        persona_id = self.get_active_persona(message, include_default=True)
+        persona = self.personas.get(persona_id)
+        if persona and persona.memory:
             persona.memory.update_history(
                 new_messages=[AgentMessage(MessageRole.USER, utt)],
                 session_id=sess.session_id
             )
 
     def handle_speak(self, message):
+        """
+        Store a system/AI utterance in the session's short-term message history.
+        
+        Appends a tuple ("ai", utterance) to self.message_history for the session identified by the incoming bus message if that session already has a history entry. If the session has no existing history entry, no action is taken.
+        
+        Parameters:
+            message: Bus message object containing `data["utterance"]` and session info retrievable via SessionManager.get(message).
+        """
         utt = message.data.get("utterance")
         sess = SessionManager.get(message)
-        persona_id: str = self.active_persona or self.default_persona
-        persona: Persona = self.personas[persona_id]
-        if persona.memory:
+        persona_id = self.get_active_persona(message, include_default=True)
+        persona = self.personas.get(persona_id)
+        if persona and persona.memory:
             persona.memory.update_history(
                 new_messages=[AgentMessage(MessageRole.ASSISTANT, utt)],
                 session_id=sess.session_id
             )
 
     def handle_persona_check(self, message: Optional[Message] = None):
-        if self.active_persona:
-            self.speak_dialog("active_persona", {"persona": self.active_persona})
+        """
+        Announces the currently active persona for the message's session.
+        
+        If a persona is active for the session resolved from `message`, speaks the
+        "active_persona" dialog with the persona name; otherwise speaks the
+        "no_active_persona" dialog.
+        
+        Parameters:
+            message (Optional[Message]): Message whose session is used to determine the
+                active persona. If omitted, resolves without a session-specific message.
+        """
+        active_persona = self.get_active_persona(message, include_default=False)
+        if active_persona:
+            self.speak_dialog("active_persona", {"persona": active_persona})
         else:
             self.speak_dialog("no_active_persona")
 
@@ -477,13 +593,21 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             self.speak(persona)
 
     def handle_persona_query(self, message):
+        """
+        Handle a persona query message by running the utterance against the resolved active persona and speaking streamed responses.
+        
+        Processes the incoming message to determine session and language, resolves the target persona (including the configured default), and validates that the persona is loaded. If no personas are available or the resolved persona is unknown, speaks the appropriate dialog and may list available personas. If valid, marks the session as active and iterates the persona's chat responses from chatbox_ask, speaking each non-empty partial result and stopping early if the session is cancelled. If no answer is produced, speaks an error dialog.
+        
+        Parameters:
+            message: MessageBus message object containing at minimum:
+                - data["utterance"]: the user's utterance text to send to the persona.
+                - optional data["lang"]: language code to use for the query; falls back to the session language.
+        """
         if not self.personas:
             self.speak_dialog("no_personas")
             return
 
-        persona_id = message.data.get("persona", self.active_persona or self.default_persona)
-        persona_id = self.get_persona(persona_id) or persona_id
-
+        persona_id = self.get_active_persona(message, include_default=True)
         if persona_id not in self.personas:
             self.speak_dialog("unknown_persona", {"persona": persona_id})
             self.handle_persona_list()
@@ -506,35 +630,62 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self._active_sessions[sess.session_id] = False
 
     def handle_persona_summon(self, message):
+        """
+        Activate a persona for the current session based on the incoming message.
+        
+        If no personas are loaded, speaks the "no_personas" dialog. Otherwise attempts to resolve the requested persona name from message.data["persona"]; if the name does not match a loaded persona, speaks the "unknown_persona" dialog with the provided name. If a matching persona is found, marks it as the active persona for the session, logs the activation, and speaks the "activated_persona" dialog.
+        
+        Parameters:
+            message: Bus message containing at least `data["persona"]` and session information used to scope the activation.
+        """
         if not self.personas:
             self.speak_dialog("no_personas")
             return
 
+        sess = SessionManager.get(message)
         persona = message.data["persona"]
-        persona = self.get_persona(persona) or persona
+        persona = self.match_persona(persona) or persona
         if persona not in self.personas:
             self.speak_dialog("unknown_persona", {"persona": persona})
         else:
             LOG.info(f"Persona enabled: {persona}")
-            self.active_persona = persona
+            self.active_personas[sess.session_id] = persona
             self.speak_dialog("activated_persona", {"persona": persona})
 
     def handle_persona_release(self, message):
         # NOTE: below never happens, this intent only matches if self.active_persona
         # if for some miracle this handle is called speak dedicated dialog
-        if not self.active_persona:
+        """
+        Release the currently active persona for the incoming message's session and announce the action.
+        
+        If a persona is active for the session, announces release via dialog, clears the session's active persona, and logs the release. If no persona is active, announces that no persona is active.
+        
+        Parameters:
+            message: The incoming message object from the message bus (provides session context).
+        """
+        active_persona = self.get_active_persona(message, include_default=False)
+        if not active_persona:
             self.speak_dialog("no_active_persona")
             return
-
-        LOG.info(f"Releasing Persona: {self.active_persona}")
-        self.speak_dialog("release_persona", {"persona": self.active_persona})
-        self.active_persona = None
-
-    def can_stop(self, message: Message) -> bool:
         sess = SessionManager.get(message)
-        return self._active_sessions.get(sess.session_id) or False
-        
+        LOG.info(f"Releasing Persona: {active_persona}  for session: {sess.session_id}")
+        self.speak_dialog("release_persona", {"persona": active_persona})
+        if sess.session_id in self.active_personas:
+            self.active_personas.pop(sess.session_id)
+
     def stop_session(self, session: Session):
+        # since responses are streaming, this will exit the loop in hanle_persona_query
+        """
+        Stop any active streaming response loop for the given session.
+        
+        Marks the session as inactive so ongoing streaming handlers (if any) will exit.
+        
+        Parameters:
+            session (Session): Session whose streaming responses should be stopped; the session's session_id is used.
+        
+        Returns:
+            bool: `True` if a running session was active and was stopped, `False` otherwise.
+        """
         if self._active_sessions.get(session.session_id):
             self._active_sessions[session.session_id] = False
             return True

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -79,11 +79,11 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                  config: Optional[Dict] = None):
         """
         Initialize the PersonaService, load configured personas and intent matchers, and register message-bus event handlers.
-        
+
         Parameters:
             bus (Optional[MessageBusClient | FakeBus]): Message bus client to use for events and IPC. If omitted, a local FakeBus is created.
             config (Optional[dict]): Persona-specific configuration; when omitted the service reads the "intents.persona" section from global Configuration.
-        
+
         Side effects:
             - Initializes base application and confidence-matching pipeline.
             - Loads personas from configured paths and plugin sources.
@@ -96,12 +96,12 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         OVOSAbstractApplication.__init__(self, bus=bus, skill_id="persona.openvoiceos",
                                          resources_dir=f"{dirname(__file__)}")
         ConfidenceMatcherPipeline.__init__(self, bus=bus, config=config)
-        self.sessions = {}
+        self.message_history = {}  # per session_id
+        self.active_personas = {}  # per session_id
         self.personas = {}
         self.intent_matchers = {}
         self.blacklist = self.config.get("persona_blacklist") or []
         self.load_personas(self.config.get("personas_path"))
-        self.active_persona = None
         # is_intent flag ensures "ovos.utterance.handled" is emitted
         self.add_event('persona:query', self.handle_persona_query, is_intent=True)
         self.add_event('persona:summon', self.handle_persona_summon, is_intent=True)
@@ -117,9 +117,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def load_resource_files(cls):
         """
         Build a mapping of language tags to intent sample lists loaded from the package locale files.
-        
+
         For each configured language (secondary_langs plus the primary lang), finds the locale directory for that language and, for each file whose name matches an entry in cls.INTENTS, reads the file as newline-separated intent samples. Each sample has doubled braces `{{` / `}}` collapsed to single `{` / `}`. Languages or intent files that are not present are skipped.
-        
+
         Returns:
             dict: A mapping {language_tag: {intent_name: [sample_str, ...], ...}, ...} containing loaded intent samples per language.
         """
@@ -144,9 +144,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         # TODO - make intent backend configurable, padatious is not a good choice...
         """
         Load and prepare intent matchers for each configured language and register persona intent samples.
-        
+
         Builds a per-language IntentContainer (using a cache directory when applicable), registers intent samples sourced from locale/resource files, and trains or instantiates matchers when the configured backend requires it. Skips training for known problematic language/intent combinations and logs failures for individual intent registrations.
-        
+
         Side effects:
         - Populates and updates self.intent_matchers with initialized IntentContainer instances keyed by language tag.
         - Reads intent samples via self.load_resource_files().
@@ -181,19 +181,37 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def default_persona(self) -> Optional[str]:
         persona = self.config.get("default_persona")
         if persona: # match config against loaded personas
-            persona = self.get_persona(persona)
+            persona = self.match_persona(persona)
         elif self.personas:
             persona = list(self.personas.keys())[0]
         return persona
 
-    def get_persona(self, persona: str):
+    def get_active_persona(self, message, include_default=True) -> Optional[str]:
+        sess = SessionManager.get(message)
+        # prioritize explicitly requested persona via message.data (eg, summon intent)
+        if message.data.get("persona"):
+            persona = self.match_persona(message.data.get("persona"))
+            if persona:
+                return persona
+        # check if a persona is active
+        if sess.session_id in self.active_personas:
+            return self.active_personas[sess.session_id]
+        # default persona from Session
+        elif sess.persona_id and include_default:
+            return sess.persona_id
+        # default persona from config
+        elif self.default_persona and include_default:
+            return self.default_persona
+        return None
+
+    def match_persona(self, persona: str):
         """
         Finds the closest matching persona name to the given input using case-insensitive partial token set matching.
         
         If no input is provided, returns the currently active persona or the default persona. Returns the matched persona name if the similarity score is at least 0.7; otherwise, returns None.
         """
         if not persona:
-            return self.active_persona or self.default_persona
+            return None
         # TODO - make MatchStrategy configurable
         match, score = match_one(persona, list(self.personas),
                                  strategy=MatchStrategy.PARTIAL_TOKEN_SET_RATIO, 
@@ -204,9 +222,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def load_personas(self, personas_path: Optional[str] = None):
         """
         Load persona definitions from the filesystem and (unless disabled) plugin providers and register them on this service.
-        
+
         Searches the given directory for JSON files and creates Persona instances for each file found, skipping any names in self.blacklist. If a JSON file provides a "name" field it is used as the persona name. Errors while loading individual persona files are logged and do not stop processing. Unless the configuration key "ignore_plugin_personas" is true, the method also queries installed persona plugins and registers those personas, skipping blacklisted names and any persona already loaded from disk.
-        
+
         Parameters:
             personas_path (Optional[str]): Directory to read user-defined persona JSON files from. If None, the XDG config path for "ovos_persona" is used.
         """
@@ -233,7 +251,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         # load personas provided by packages
         if self.config.get("ignore_plugin_personas", False):
             return
-            
+
         for name, persona in find_persona_plugins().items():
             if name in self.blacklist:
                 continue
@@ -250,7 +268,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.personas[name] = Persona(name, persona)
 
     def deregister_persona(self, name):
-        name = self.get_persona(name) or ""
+        name = self.match_persona(name) or ""
         if name in self.personas:
             self.personas.pop(name)
 
@@ -260,7 +278,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                     lang: Optional[str] = None,
                     message: Message = None,
                     stream: bool = True) -> Iterable[str]:
-        persona = self.get_persona(persona) or self.active_persona or self.default_persona
+        persona = self.match_persona(persona) or self.get_active_persona(message, include_default=True)
         if persona not in self.personas:
             LOG.error(f"unknown persona, choose one of {self.personas.keys()}")
             return None
@@ -284,13 +302,13 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     def _build_msg_history(self, message: Message):
         sess = SessionManager.get(message)
-        if sess.session_id not in self.sessions:
+        if sess.session_id not in self.message_history:
             return []
         messages = []  # tuple of question, answer
 
         q = None
         ans = None
-        for m in self.sessions[sess.session_id]:
+        for m in self.message_history[sess.session_id]:
             if m[0] == "user":
                 if ans is not None and q is not None:
                     # save previous q/a pair
@@ -325,10 +343,10 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         """
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
-
-        if self.active_persona and self.voc_match(utterances[0], "Release", lang):
+        active_persona = self.get_active_persona(message, include_default=False)
+        if active_persona and self.voc_match(utterances[0], "Release", lang):
             return IntentHandlerMatch(match_type='persona:release',
-                                      match_data={"persona": self.active_persona},
+                                      match_data={"persona": active_persona},
                                       skill_id="persona.openvoiceos",
                                       utterance=utterances[0])
 
@@ -364,7 +382,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                                               utterance=utterances[0])
                 elif name == "ask.intent" and persona and query:
                     # if persona name or query not in match, its a misclassification
-                    persona = self.get_persona(persona)
+                    persona = self.match_persona(persona)
                     if persona: # name in intent must match a registered persona
                         return IntentHandlerMatch(match_type='persona:query',
                                                   match_data={"utterance": query,
@@ -377,17 +395,18 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                         # TODO - consider matching and reprompting user
 
             # override regular intent parsing, handle utterance until persona is released
-            if self.active_persona:
-                LOG.debug(f"Persona is active: {self.active_persona}")
+            if active_persona:
+                LOG.debug(f"Persona is active: {active_persona}")
                 return self.match_low(utterances, lang, message)
 
     def match_medium(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
 
-        if self.active_persona and self.voc_match(utterances[0], "Release", lang):
+        active_persona = self.get_active_persona(message, include_default=False)
+        if active_persona and self.voc_match(utterances[0], "Release", lang):
             return IntentHandlerMatch(match_type='persona:release',
-                                      match_data={"persona": self.active_persona},
+                                      match_data={"persona": active_persona},
                                       skill_id="persona.openvoiceos",
                                       utterance=utterances[0])
 
@@ -434,7 +453,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                                               skill_id="persona.openvoiceos",
                                               utterance=utterances[0])
                 elif name == "ask.intent" and persona:  # if persona name not in match, its a misclassification
-                    persona = self.get_persona(persona)
+                    persona = self.match_persona(persona)
                     if persona and query:  # else its a misclassification
                         utterance = match["entities"].pop("query")
                         return IntentHandlerMatch(match_type='persona:query',
@@ -461,18 +480,19 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         if match:
             return match
 
-        persona = self.active_persona
-        if self.config.get("handle_fallback"):
-            # read default persona from config
-            persona = persona or self.default_persona
+        persona = self.get_active_persona(message, include_default=False)
+        if not persona and self.config.get("handle_fallback"):
+            # read default persona from session/config
+            persona = self.get_active_persona(message, include_default=True)
             if not persona:
                 LOG.error("configured default persona is invalid, can't handle utterance")
+
         # always matches! use as last resort in pipeline
         if persona:
             return IntentHandlerMatch(match_type='persona:query',
                                       match_data={"utterance": utterances[0],
                                                   "lang": lang,
-                                                  "persona": self.active_persona or self.default_persona},
+                                                  "persona": persona},
                                       skill_id="persona.openvoiceos",
                                       utterance=utterances[0])
 
@@ -480,19 +500,20 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def handle_utterance(self, message):
         utt = message.data.get("utterances")[0]
         sess = SessionManager.get(message)
-        if sess.session_id not in self.sessions:
-            self.sessions[sess.session_id] = []
-        self.sessions[sess.session_id].append(("user", utt))
+        if sess.session_id not in self.message_history:
+            self.message_history[sess.session_id] = []
+        self.message_history[sess.session_id].append(("user", utt))
 
     def handle_speak(self, message):
         utt = message.data.get("utterance")
         sess = SessionManager.get(message)
-        if sess.session_id in self.sessions:
-            self.sessions[sess.session_id].append(("ai", utt))
+        if sess.session_id in self.message_history:
+            self.message_history[sess.session_id].append(("ai", utt))
 
     def handle_persona_check(self, message: Optional[Message] = None):
-        if self.active_persona:
-            self.speak_dialog("active_persona", {"persona": self.active_persona})
+        active_persona = self.get_active_persona(message, include_default=False)
+        if active_persona:
+            self.speak_dialog("active_persona", {"persona": active_persona})
         else:
             self.speak_dialog("no_active_persona")
 
@@ -513,8 +534,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         sess = SessionManager.get(message)
         utt = message.data["utterance"]
         lang = message.data.get("lang") or sess.lang
-        persona = message.data.get("persona", self.active_persona or self.default_persona)
-        persona = self.get_persona(persona) or persona
+        persona = self.get_active_persona(message, include_default=True)
         if persona not in self.personas:
             self.speak_dialog("unknown_persona", {"persona": persona})
             self.handle_persona_list()
@@ -542,27 +562,30 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             self.speak_dialog("no_personas")
             return
 
+        sess = SessionManager.get(message)
         persona = message.data["persona"]
-        persona = self.get_persona(persona) or persona
+        persona = self.match_persona(persona) or persona
         if persona not in self.personas:
             self.speak_dialog("unknown_persona", {"persona": persona})
         else:
             LOG.info(f"Persona enabled: {persona}")
-            self.active_persona = persona
+            self.active_personas[sess.session_id] = persona
             self.speak_dialog("activated_persona", {"persona": persona})
 
     def handle_persona_release(self, message):
         # NOTE: below never happens, this intent only matches if self.active_persona
         # if for some miracle this handle is called speak dedicated dialog
-        if not self.active_persona:
+        active_persona = self.get_active_persona(message, include_default=False)
+        if not active_persona:
             self.speak_dialog("no_active_persona")
             return
-
-        LOG.info(f"Releasing Persona: {self.active_persona}")
-        self.speak_dialog("release_persona", {"persona": self.active_persona})
-        self.active_persona = None
+        sess = SessionManager.get(message)
+        LOG.info(f"Releasing Persona: {active_persona}  for session: {sess.session_id}")
+        self.speak_dialog("release_persona", {"persona": active_persona})
+        self.active_personas[sess.session_id] = None
 
     def stop_session(self, session: Session):
+        # since responses are streaming, this will exit the loop in hanle_persona_query
         if self._active_sessions.get(session.session_id):
             self._active_sessions[session.session_id] = False
             return True

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -186,10 +186,10 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             persona = list(self.personas.keys())[0]
         return persona
 
-    def get_active_persona(self, message, include_default=True) -> Optional[str]:
+    def get_active_persona(self, message: Optional[Message]=None, include_default=True) -> Optional[str]:
         sess = SessionManager.get(message)
         # prioritize explicitly requested persona via message.data (eg, summon intent)
-        if message.data.get("persona"):
+        if message and message.data.get("persona"):
             persona = self.match_persona(message.data.get("persona"))
             if persona:
                 return persona
@@ -208,7 +208,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         """
         Finds the closest matching persona name to the given input using case-insensitive partial token set matching.
         
-        If no input is provided, returns the currently active persona or the default persona. Returns the matched persona name if the similarity score is at least 0.7; otherwise, returns None.
+        Returns the matched persona name if the similarity score is at least 0.7; otherwise, returns None.
         """
         if not persona:
             return None
@@ -582,7 +582,8 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         sess = SessionManager.get(message)
         LOG.info(f"Releasing Persona: {active_persona}  for session: {sess.session_id}")
         self.speak_dialog("release_persona", {"persona": active_persona})
-        self.active_personas[sess.session_id] = None
+        if sess.session_id in self.active_personas:
+            self.active_personas.pop(sess.session_id)
 
     def stop_session(self, session: Session):
         # since responses are streaming, this will exit the loop in hanle_persona_query

--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -78,18 +78,18 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def __init__(self, bus: Optional[Union[MessageBusClient, FakeBus]] = None,
                  config: Optional[Dict] = None):
         """
-        Initialize the PersonaService, load configured personas and intent matchers, and register message-bus event handlers.
-
+        Create and initialize the PersonaService, load personas and intent matchers, and register message-bus handlers.
+         
         Parameters:
-            bus (Optional[MessageBusClient | FakeBus]): Message bus client to use for events and IPC. If omitted, a local FakeBus is created.
-            config (Optional[dict]): Persona-specific configuration; when omitted the service reads the "intents.persona" section from global Configuration.
-
-        Side effects:
+            bus (Optional[MessageBusClient | FakeBus]): Message bus client used for events and IPC. If omitted, a local FakeBus is created.
+            config (Optional[dict]): Persona-specific configuration. If omitted, the service reads the "intents.persona" section from global Configuration.
+         
+        Behavior:
             - Initializes base application and confidence-matching pipeline.
-            - Loads personas from configured paths and plugin sources.
-            - Registers intent-related and session event handlers on the bus.
+            - Loads personas from configured paths and plugin providers.
             - Loads per-language intent matcher files.
-            - Initializes runtime attributes: `sessions`, `personas`, `intent_matchers`, `blacklist`, `active_persona`, and `_active_sessions`.
+            - Registers message-bus event handlers for persona operations and utterance/speak events.
+            - Initializes runtime state: `message_history` (per-session history), `active_personas` (per-session active persona), `personas`, `intent_matchers`, `blacklist`, and `_active_sessions`.
         """
         bus = bus or FakeBus()
         config = config or Configuration().get("intents", {}).get("persona", {})
@@ -116,12 +116,12 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     @classmethod
     def load_resource_files(cls):
         """
-        Build a mapping of language tags to intent sample lists loaded from the package locale files.
-
-        For each configured language (secondary_langs plus the primary lang), finds the locale directory for that language and, for each file whose name matches an entry in cls.INTENTS, reads the file as newline-separated intent samples. Each sample has doubled braces `{{` / `}}` collapsed to single `{` / `}`. Languages or intent files that are not present are skipped.
-
+        Load intent sample texts from this package's locale resources for configured languages.
+        
+        For each language in Configuration().get('secondary_langs') plus the primary language (Configuration().get('lang')), locate the package locale directory for that language and collect files whose names match entries in cls.INTENTS. Each matching file is read as newline-separated samples; doubled braces `{{` / `}}` in samples are collapsed to single `{` / `}`. Missing languages or intent files are skipped.
+        
         Returns:
-            dict: A mapping {language_tag: {intent_name: [sample_str, ...], ...}, ...} containing loaded intent samples per language.
+            dict: Mapping from language tag to a dict of intent name -> list of sample strings, i.e. {language: {intent_name: [sample, ...], ...}, ...}.
         """
         intents = {}
         langs = Configuration().get('secondary_langs', []) + [Configuration().get('lang', "en-US")]
@@ -179,6 +179,14 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     @property
     def default_persona(self) -> Optional[str]:
+        """
+        Determine the default persona name for this service.
+        
+        If a `default_persona` is configured, returns the best-matching loaded persona name. If no configuration is present but personas are loaded, returns the first loaded persona name. Returns `None` when no persona can be resolved.
+        
+        Returns:
+            Optional[str]: The resolved persona name, or `None` if no personas are available.
+        """
         persona = self.config.get("default_persona")
         if persona: # match config against loaded personas
             persona = self.match_persona(persona)
@@ -186,7 +194,19 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             persona = list(self.personas.keys())[0]
         return persona
 
-    def get_active_persona(self, message: Optional[Message]=None, include_default=True) -> Optional[str]:
+    def get_active_persona(self, message, include_default=True) -> Optional[str]:
+        """
+        Determine the active persona for the given message/session following priority rules.
+        
+        Checks, in order: an explicitly requested persona in message.data, a session-scoped active persona, the session's default persona (if include_default), and the configured default persona (if include_default).
+        
+        Parameters:
+            message: The incoming message object containing session/context data.
+            include_default (bool): If True, allow falling back to the session or configured default persona.
+        
+        Returns:
+            Optional[str]: The resolved persona name if one is found, `None` otherwise.
+        """
         sess = SessionManager.get(message)
         # prioritize explicitly requested persona via message.data (eg, summon intent)
         if message and message.data.get("persona"):
@@ -206,9 +226,13 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     def match_persona(self, persona: str):
         """
-        Finds the closest matching persona name to the given input using case-insensitive partial token set matching.
+        Finds the registered persona name that best matches the given input using case-insensitive partial token-set fuzzy matching.
         
-        Returns the matched persona name if the similarity score is at least 0.7; otherwise, returns None.
+        Parameters:
+            persona (str): Candidate persona name or phrase to match against registered personas.
+        
+        Returns:
+            str or None: The matched persona name if the similarity score is at least 0.7, `None` if the input is empty or no persona meets the threshold.
         """
         if not persona:
             return None
@@ -221,10 +245,10 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     def load_personas(self, personas_path: Optional[str] = None):
         """
-        Load persona definitions from the filesystem and (unless disabled) plugin providers and register them on this service.
-
-        Searches the given directory for JSON files and creates Persona instances for each file found, skipping any names in self.blacklist. If a JSON file provides a "name" field it is used as the persona name. Errors while loading individual persona files are logged and do not stop processing. Unless the configuration key "ignore_plugin_personas" is true, the method also queries installed persona plugins and registers those personas, skipping blacklisted names and any persona already loaded from disk.
-
+        Discover and register persona definitions from disk and from installed persona plugins into this service.
+        
+        Scans the provided directory for JSON files (or the XDG config path if None), creates Persona instances for each file found, and registers them under their filename or the JSON's "name" field. Skips personas present in self.blacklist. Errors while loading individual persona files are logged and do not stop processing. Unless the configuration key "ignore_plugin_personas" is true, also loads persona definitions discovered from installed plugin providers, skipping blacklisted names and any persona already loaded from disk.
+        
         Parameters:
             personas_path (Optional[str]): Directory to read user-defined persona JSON files from. If None, the XDG config path for "ovos_persona" is used.
         """
@@ -265,9 +289,22 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 LOG.error(f"Failed to load '{name}': {e}")
 
     def register_persona(self, name, persona):
+        """
+        Register or update a persona under the given name using the provided configuration.
+        
+        Parameters:
+            name (str): Identifier for the persona.
+            persona (dict): Persona configuration dictionary used to construct the Persona instance.
+        """
         self.personas[name] = Persona(name, persona)
 
     def deregister_persona(self, name):
+        """
+        Deregister a persona by name, removing it from the service's registry if found.
+        
+        Parameters:
+            name (str): Exact or partial persona name to remove; the input will be resolved to a registered persona (fuzzy/case-insensitive match) before removal.
+        """
         name = self.match_persona(name) or ""
         if name in self.personas:
             self.personas.pop(name)
@@ -278,6 +315,21 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                     lang: Optional[str] = None,
                     message: Message = None,
                     stream: bool = True) -> Iterable[str]:
+        """
+        Ask a persona a prompt and yield its response(s), optionally as a streamed sequence.
+        
+        The target persona is resolved from the provided `persona` (fuzzy match) or from the message/session active persona (including the configured default). If short-term memory is enabled, recent per-session Q/A pairs from `message` are prepended to the prompt as context. Streaming delegates to the persona's streaming interface; non-streaming returns the full reply as a single yielded string.
+        
+        Parameters:
+            prompt (str): The user prompt to send to the persona.
+            persona (Optional[str]): Persona name or partial name to resolve; if omitted, the active/session/default persona is used.
+            lang (Optional[str]): Language tag to use for the request; if omitted, the session language is used.
+            message (Message): Optional message object used to resolve the session, language, and to gather short-term memory.
+            stream (bool): If True, yield incremental/streamed response fragments; if False, yield one complete response.
+        
+        Returns:
+            Iterable[str]: An iterator that yields response strings. Returns None (and yields nothing) if the resolved persona is not found.
+        """
         persona = self.match_persona(persona) or self.get_active_persona(message, include_default=True)
         if persona not in self.personas:
             LOG.error(f"unknown persona, choose one of {self.personas.keys()}")
@@ -301,6 +353,17 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 yield ans
 
     def _build_msg_history(self, message: Message):
+        """
+        Reconstructs recent question/answer pairs for the session associated with `message`.
+        
+        Scans the per-session message_history for the session id derived from `message` and returns a list of (question, answer) tuples in chronological order. Consecutive AI "speak" entries are concatenated into a single answer separated by ". ". If no history exists for the session, returns an empty list.
+        
+        Parameters:
+            message (Message): Bus message used to obtain the session and session_id.
+        
+        Returns:
+            list[tuple[str, str]]: Chronological list of (question, answer) pairs for the session.
+        """
         sess = SessionManager.get(message)
         if sess.session_id not in self.message_history:
             return []
@@ -331,15 +394,25 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def match_high(self, utterances: List[str], lang: Optional[str] = None,
                    message: Optional[Message] = None) -> Optional[IntentHandlerMatch]:
         """
-        Recommended before common query
-
-        Args:
-            utterances (list):  list of utterances
-            lang (string):      4 letter ISO language code
-            message (Message):  message to use to generate reply
-
+        High-priority intent matcher for persona-related utterances.
+       
+        Analyzes the first utterance (language-normalized) for persona control and query intents. It:
+        - Detects a release intent when a session has an active persona and returns a 'persona:release' match.
+        - Uses per-language intent matchers to identify persona intents (summon, list, active_persona, ask).
+        - Applies the configured minimum intent confidence threshold before accepting a match.
+        - For 'summon.intent', returns a 'persona:summon' match when a persona entity is present.
+        - For 'list_personas.intent', returns a 'persona:list' match.
+        - For 'active_persona.intent', returns a 'persona:check' match.
+        - For 'ask.intent', requires both persona and utterance entities and verifies the persona against registered personas via match_persona; returns a 'persona:query' match when verified.
+        - If an active persona exists and no explicit persona intent is accepted, delegates to the low-priority matcher to allow persona-scoped handling.
+       
+        Parameters:
+            utterances (List[str]): Candidate user utterances; only the first entry is used for matching.
+            lang (Optional[str]): Language tag to use for intent matching; will be standardized if provided.
+            message (Optional[Message]): Message object providing session/context (used to detect session active persona).
+       
         Returns:
-            IntentMatch if handled otherwise None.
+            IntentHandlerMatch or None: An IntentHandlerMatch for handled persona intents (`persona:release`, `persona:summon`, `persona:list`, `persona:check`, `persona:query`) or `None` if no high-priority persona intent was matched.
         """
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
@@ -400,6 +473,19 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 return self.match_low(utterances, lang, message)
 
     def match_medium(self, utterances: List[str], lang: str, message: Message) -> Optional[IntentHandlerMatch]:
+        """
+        Attempt medium-priority intent matching for persona-related utterances and return a corresponding IntentHandlerMatch when detected.
+        
+        Normalizes the language tag and checks, in order: (1) if a session has an active persona and the utterance matches a "Release" vocabulary, return a 'persona:release' match; (2) perform an adapt-like heuristic for queries that mention a known persona name and match "ask" + "opinion" or "summon" vocabularies, returning a 'persona:query' or 'persona:summon' match with extracted persona and query data. Matches use the closest supported language available and require both a resolved persona and query where applicable; misclassifications are ignored.
+        
+        Parameters:
+            utterances (List[str]): Candidate utterances (first element is used as the primary input).
+            lang (str): Requested language tag or None to use the service default.
+            message (Message): The incoming message object (used to resolve session-specific active persona).
+        
+        Returns:
+            IntentHandlerMatch or None: An IntentHandlerMatch for 'persona:release', 'persona:summon', or 'persona:query' when a medium-priority persona intent is found, otherwise None.
+        """
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
 
@@ -466,15 +552,17 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def match_low(self, utterances: List[str], lang: Optional[str] = None,
                   message: Optional[Message] = None) -> Optional[IntentHandlerMatch]:
         """
-        Recommended before fallback low
-
-        Args:
-            utterances (list):  list of utterances
-            lang (string):      4 letter ISO language code
-            message (Message):  message to use to generate reply
-
+        Attempt a final fallback match that routes the first utterance to an active or default persona.
+          
+        If a higher-priority medium match is found, it is returned. Otherwise, this method resolves the session's active persona (or the configured default when allowed) and constructs an IntentHandlerMatch of type "persona:query" containing the first utterance, language, and resolved persona. This match is intended as the last-resort handler in the matching pipeline and only produced when a persona is available (and fallback handling is enabled when necessary).
+          
+        Parameters:
+            utterances (List[str]): Candidate utterances (first element is used for the fallback query).
+            lang (Optional[str]): Language tag (e.g., "en-US") used for context resolution.
+            message (Optional[Message]): Optional message object used to resolve session-specific active persona.
+          
         Returns:
-            IntentMatch if handled otherwise None.
+            Optional[IntentHandlerMatch]: An IntentHandlerMatch of type "persona:query" when a fallback persona is resolved, `None` if no persona match or fallback is applicable.
         """
         match = self.match_medium(utterances, lang, message)
         if match:
@@ -498,6 +586,18 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     # bus events
     def handle_utterance(self, message):
+        """
+        Store the incoming user utterance in the per-session message history.
+        
+        Parameters:
+            message: Bus message object containing a `data` dict with an `utterances` list.
+                The first element of that list is taken as the user utterance. The session
+                is resolved via SessionManager.get(message); its `session_id` is used as
+                the key in `self.message_history`.
+        
+        Side effects:
+            Appends a tuple `("user", utterance)` to `self.message_history[session_id]`.
+        """
         utt = message.data.get("utterances")[0]
         sess = SessionManager.get(message)
         if sess.session_id not in self.message_history:
@@ -505,12 +605,31 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.message_history[sess.session_id].append(("user", utt))
 
     def handle_speak(self, message):
+        """
+        Store a system/AI utterance in the session's short-term message history.
+        
+        Appends a tuple ("ai", utterance) to self.message_history for the session identified by the incoming bus message if that session already has a history entry. If the session has no existing history entry, no action is taken.
+        
+        Parameters:
+            message: Bus message object containing `data["utterance"]` and session info retrievable via SessionManager.get(message).
+        """
         utt = message.data.get("utterance")
         sess = SessionManager.get(message)
         if sess.session_id in self.message_history:
             self.message_history[sess.session_id].append(("ai", utt))
 
     def handle_persona_check(self, message: Optional[Message] = None):
+        """
+        Announces the currently active persona for the message's session.
+        
+        If a persona is active for the session resolved from `message`, speaks the
+        "active_persona" dialog with the persona name; otherwise speaks the
+        "no_active_persona" dialog.
+        
+        Parameters:
+            message (Optional[Message]): Message whose session is used to determine the
+                active persona. If omitted, resolves without a session-specific message.
+        """
         active_persona = self.get_active_persona(message, include_default=False)
         if active_persona:
             self.speak_dialog("active_persona", {"persona": active_persona})
@@ -527,6 +646,16 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             self.speak(persona)
 
     def handle_persona_query(self, message):
+        """
+        Handle a persona query message by running the utterance against the resolved active persona and speaking streamed responses.
+        
+        Processes the incoming message to determine session and language, resolves the target persona (including the configured default), and validates that the persona is loaded. If no personas are available or the resolved persona is unknown, speaks the appropriate dialog and may list available personas. If valid, marks the session as active and iterates the persona's chat responses from chatbox_ask, speaking each non-empty partial result and stopping early if the session is cancelled. If no answer is produced, speaks an error dialog.
+        
+        Parameters:
+            message: MessageBus message object containing at minimum:
+                - data["utterance"]: the user's utterance text to send to the persona.
+                - optional data["lang"]: language code to use for the query; falls back to the session language.
+        """
         if not self.personas:
             self.speak_dialog("no_personas")
             return
@@ -558,6 +687,14 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self._active_sessions[sess.session_id] = False
 
     def handle_persona_summon(self, message):
+        """
+        Activate a persona for the current session based on the incoming message.
+        
+        If no personas are loaded, speaks the "no_personas" dialog. Otherwise attempts to resolve the requested persona name from message.data["persona"]; if the name does not match a loaded persona, speaks the "unknown_persona" dialog with the provided name. If a matching persona is found, marks it as the active persona for the session, logs the activation, and speaks the "activated_persona" dialog.
+        
+        Parameters:
+            message: Bus message containing at least `data["persona"]` and session information used to scope the activation.
+        """
         if not self.personas:
             self.speak_dialog("no_personas")
             return
@@ -575,6 +712,14 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def handle_persona_release(self, message):
         # NOTE: below never happens, this intent only matches if self.active_persona
         # if for some miracle this handle is called speak dedicated dialog
+        """
+        Release the currently active persona for the incoming message's session and announce the action.
+        
+        If a persona is active for the session, announces release via dialog, clears the session's active persona, and logs the release. If no persona is active, announces that no persona is active.
+        
+        Parameters:
+            message: The incoming message object from the message bus (provides session context).
+        """
         active_persona = self.get_active_persona(message, include_default=False)
         if not active_persona:
             self.speak_dialog("no_active_persona")
@@ -587,6 +732,17 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
 
     def stop_session(self, session: Session):
         # since responses are streaming, this will exit the loop in hanle_persona_query
+        """
+        Stop any active streaming response loop for the given session.
+        
+        Marks the session as inactive so ongoing streaming handlers (if any) will exit.
+        
+        Parameters:
+            session (Session): Session whose streaming responses should be stopped; the session's session_id is used.
+        
+        Returns:
+            bool: `True` if a running session was active and was stopped, `False` otherwise.
+        """
         if self._active_sessions.get(session.session_id):
             self._active_sessions[session.session_id] = False
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ Issues = "https://github.com/OpenVoiceOS/ovos-persona/issues"
 [project.entry-points."opm.pipeline"]
 ovos-persona-pipeline-plugin = "ovos_persona:PersonaService"
 
+[project.entry-points."opm.agents.memory"]
+ovos-agents-short-term-memory-plugin = "ovos_persona.memory:BasicShortTermMemory"
+
 [tool.setuptools.dynamic]
 version = { attr = "ovos_persona.version.__version__" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
+    "ovoscope",
+    "ovos-solver-failure-plugin",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ ovos-plugin-manager>=0.8.3,<3.0.0
 ovos-openai-plugin>=2.0.0,<3.0.0
 ovos-solver-failure-plugin
 ovos-utils>=0.8.0a1,<1.0.0
+ovos-bus-client>=1.5.0,<2.0.0
 langcodes

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ ovos-plugin-manager>=0.8.3,<3.0.0
 ovos-openai-plugin>=2.0.0,<3.0.0
 ovos-solver-failure-plugin
 ovos-utils>=0.8.0a1,<1.0.0
-ovos-bus-client>=1.5.0,<2.0.0
+ovos-bus-client>=1.4.0,<2.0.0
 langcodes

--- a/test/test_e2e_ovoscope.py
+++ b/test/test_e2e_ovoscope.py
@@ -1,0 +1,247 @@
+"""Full-pipeline end-to-end test for ovos-persona using ovoscope (PR #140).
+
+Proves:
+  1. An utterance flows through the real OVOS intent pipeline, hits the persona
+     pipeline plugin, and produces a ``speak`` message (the persona answered).
+  2. Per-session memory is recorded: the live PersonaService accumulates USER +
+     ASSISTANT turns keyed by session_id, and an unknown session has no history.
+
+No network access, no LLM downloads.  ``ovos-solver-failure-plugin`` is used as
+the deterministic chat backend — it always returns a spoken answer.
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+ovoscope = pytest.importorskip("ovoscope")
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+
+from ovoscope import (
+    PERSONA_PIPELINE,
+    CaptureSession,
+    get_minicroft,
+    is_pipeline_available,
+)
+
+# ---------------------------------------------------------------------------
+# Skip whole module if the persona pipeline plugin is not installed
+# ---------------------------------------------------------------------------
+if not is_pipeline_available(PERSONA_PIPELINE):
+    pytest.skip("ovos-persona-pipeline-plugin not installed", allow_module_level=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_personas_dir(name: str = "Tester") -> str:
+    """Write a minimal persona JSON into a temp directory and return the path."""
+    tmpdir = tempfile.mkdtemp()
+    persona = {"name": name, "solvers": ["ovos-solver-failure-plugin"]}
+    with open(os.path.join(tmpdir, f"{name}.json"), "w") as fh:
+        json.dump(persona, fh)
+    return tmpdir
+
+
+def _utterance_msg(utterance: str, sess: Session) -> Message:
+    return Message(
+        "recognizer_loop:utterance",
+        {"utterances": [utterance], "lang": sess.lang},
+        {"session": sess.serialize()},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level MiniCroft (shared across tests for speed)
+# ---------------------------------------------------------------------------
+
+PERSONA_NAME = "Tester"
+PERSONAS_PATH = _make_personas_dir(PERSONA_NAME)
+
+PIPELINE_CONFIG = {
+    "persona": {
+        "personas_path": PERSONAS_PATH,
+        "default_persona": PERSONA_NAME,
+        "short-term-memory": True,
+        "handle_fallback": True,          # route unmatched utterances to persona
+        "ignore_plugin_personas": True,   # only use the Tester persona we created
+    }
+}
+
+# Use the persona pipeline stages plus fallback so free-form utterances reach
+# match_low (which honours handle_fallback) when no other intent fires first.
+TEST_PIPELINE = [
+    "ovos-persona-pipeline-plugin-high",
+    "ovos-persona-pipeline-plugin-low",
+]
+
+
+@pytest.fixture(scope="module")
+def mc():
+    croft = get_minicroft(
+        skill_ids=[],
+        default_pipeline=TEST_PIPELINE,
+        pipeline_config=PIPELINE_CONFIG,
+    )
+    yield croft
+    croft.stop()
+
+
+# ---------------------------------------------------------------------------
+# Helpers that need the live croft
+# ---------------------------------------------------------------------------
+
+def _get_persona_service(croft):
+    """Return the live PersonaService instance from the running MiniCroft."""
+    return croft.intents.pipeline_plugins["ovos-persona-pipeline-plugin"]
+
+
+def _drive_utterance(croft, sess: Session, utterance: str, timeout: int = 30):
+    """Emit a recognizer_loop:utterance and collect bus messages until EOF."""
+    cap = CaptureSession(
+        croft,
+        eof_msgs=["ovos.utterance.handled", "ovos.utterance.cancelled"],
+    )
+    cap.capture(_utterance_msg(utterance, sess), timeout=timeout)
+    return cap.finish()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: persona speaks through the full pipeline
+# ---------------------------------------------------------------------------
+
+class TestPersonaSpeaksThroughPipeline:
+    """The utterance must traverse the full OVOS intent pipeline and produce
+    a speak message with non-empty utterance text."""
+
+    def test_pipeline_produces_speak(self, mc):
+        sess = Session(session_id="e2e-speak-test")
+        SessionManager.sessions[sess.session_id] = sess
+
+        messages = _drive_utterance(mc, sess, "hello there", timeout=30)
+
+        msg_types = [m.msg_type for m in messages]
+        speak_msgs = [m for m in messages if m.msg_type == "speak"]
+
+        assert speak_msgs, (
+            f"Expected at least one 'speak' message; got msg_types: {msg_types}"
+        )
+        spoken = speak_msgs[0].data.get("utterance", "")
+        assert spoken.strip(), (
+            f"'speak' message had an empty utterance; data={speak_msgs[0].data}"
+        )
+
+    def test_speak_message_has_non_empty_utterance(self, mc):
+        sess = Session(session_id="e2e-speak-nonempty")
+        SessionManager.sessions[sess.session_id] = sess
+
+        messages = _drive_utterance(mc, sess, "what is the meaning of life", timeout=30)
+
+        for msg in messages:
+            if msg.msg_type == "speak":
+                assert msg.data.get("utterance", "").strip(), (
+                    f"speak message has empty utterance: {msg.data}"
+                )
+                return   # found a non-empty speak — test passes
+
+        pytest.fail(
+            f"No 'speak' message found in pipeline output. "
+            f"Message types received: {[m.msg_type for m in messages]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: per-session memory is recorded
+# ---------------------------------------------------------------------------
+
+class TestPerSessionMemory:
+    """PersonaService records USER+ASSISTANT turns per session_id.
+
+    The live PersonaService is obtained from the MiniCroft pipeline registry
+    (mc.intents.pipeline_plugins["ovos-persona-pipeline-plugin"]).
+
+    Note: full *state-isolation* between two concurrent sessions (no cross-
+    contamination) is covered by test_session_e2e.py::TestMemoryIsolation,
+    which exercises the handlers directly.  Here we verify the end-to-end
+    memory write path: a turn driven through the real pipeline must appear
+    in persona.memory.get_history(session_id).
+    """
+
+    def test_user_turn_recorded_in_memory(self, mc):
+        svc = _get_persona_service(mc)
+        sess = Session(session_id="e2e-mem-user")
+        SessionManager.sessions[sess.session_id] = sess
+
+        persona = svc.personas.get(PERSONA_NAME)
+        assert persona is not None, f"Persona '{PERSONA_NAME}' not loaded"
+        assert persona.memory is not None, "Persona must have short-term memory enabled"
+
+        # drive a real pipeline turn
+        _drive_utterance(mc, sess, "remember this for me", timeout=30)
+
+        history = persona.memory.get_history(sess.session_id)
+        contents = [m.content for m in history]
+        assert any("remember this for me" in c for c in contents), (
+            f"User utterance not found in memory for session {sess.session_id}. "
+            f"History: {contents}"
+        )
+
+    def test_assistant_response_recorded_in_memory(self, mc):
+        svc = _get_persona_service(mc)
+        sess = Session(session_id="e2e-mem-assistant")
+        SessionManager.sessions[sess.session_id] = sess
+
+        persona = svc.personas.get(PERSONA_NAME)
+        assert persona is not None
+        assert persona.memory is not None
+
+        _drive_utterance(mc, sess, "say something back", timeout=30)
+
+        from ovos_plugin_manager.templates.agents import MessageRole
+        history = persona.memory.get_history(sess.session_id)
+        roles = [m.role for m in history]
+        assert MessageRole.ASSISTANT in roles, (
+            f"No ASSISTANT turn recorded in memory. History roles: {roles}"
+        )
+
+    def test_unknown_session_has_empty_history(self, mc):
+        svc = _get_persona_service(mc)
+        persona = svc.personas.get(PERSONA_NAME)
+        assert persona is not None
+        assert persona.memory is not None
+
+        # drive a turn for a known session first
+        sess = Session(session_id="e2e-mem-known")
+        SessionManager.sessions[sess.session_id] = sess
+        _drive_utterance(mc, sess, "hello", timeout=30)
+
+        # a session that never interacted must have empty history
+        unknown_history = persona.memory.get_history("session-that-never-existed")
+        assert unknown_history == [], (
+            f"Expected empty history for unknown session, got: {unknown_history}"
+        )
+
+    def test_same_session_accumulates_turns(self, mc):
+        """Driving two utterances on the same session accumulates history."""
+        svc = _get_persona_service(mc)
+        sess = Session(session_id="e2e-mem-accumulate")
+        SessionManager.sessions[sess.session_id] = sess
+
+        persona = svc.personas.get(PERSONA_NAME)
+        assert persona is not None
+        assert persona.memory is not None
+        # clear any previous history for this session id
+        persona.memory.session2history.pop(sess.session_id, None)
+
+        _drive_utterance(mc, sess, "first question", timeout=30)
+        _drive_utterance(mc, sess, "second question", timeout=30)
+
+        history = persona.memory.get_history(sess.session_id)
+        assert len(history) >= 2, (
+            f"Expected at least 2 history entries after two turns, got {len(history)}: "
+            f"{[m.content for m in history]}"
+        )

--- a/test/test_session_e2e.py
+++ b/test/test_session_e2e.py
@@ -2,7 +2,7 @@
 
 PersonaService keeps independent state per session:
   - active_personas: {session_id -> persona name}
-  - active_personas: {session_id -> persona name}
+  - per-session conversation memory (BasicShortTermMemory keyed by session_id)
 
 All tests drive the real PersonaService handlers through a FakeBus;
 no network access or LLM downloads are required (ovos-solver-failure-plugin only).
@@ -77,15 +77,20 @@ def svc():
 
 @pytest.fixture(autouse=True)
 def fresh_sessions(svc):
-    """Reset per-session state between tests so tests are independent."""
-    svc.active_personas.clear()
-    svc._active_sessions.clear()
+    """Reset per-session state (active personas + conversation memory) between tests."""
+    def _reset():
+        svc.active_personas.clear()
+        svc._active_sessions.clear()
+        for _p in svc.personas.values():
+            if _p.memory:
+                _p.memory.session2history.clear()
+    _reset()
     # Re-register sessions in the global SessionManager
     for sid in ("s1", "s2"):
         sess = Session(session_id=sid)
         SessionManager.sessions[sid] = sess
     yield
-    svc.active_personas.clear()
+    _reset()
 
 
 # ---------------------------------------------------------------------------
@@ -171,3 +176,50 @@ class TestDefaultFallback:
         sess1 = SessionManager.sessions["s1"]
         persona = svc.get_active_persona(_msg(sess1), include_default=False)
         assert persona is None
+
+
+class TestMemoryIsolation:
+    """Conversation memory must stay isolated per session, end-to-end."""
+
+    def test_memory_isolated_per_session_same_persona(self, svc):
+        """Two sessions on the default persona keep independent histories."""
+        sess1 = SessionManager.sessions["s1"]
+        sess2 = SessionManager.sessions["s2"]
+
+        # drive the REAL handlers (no summon -> both use the default persona)
+        svc.handle_utterance(_utterance_msg(sess1, "my secret is s1-token"))
+        svc.handle_speak(_speak_msg(sess1, "acknowledged s1-token"))
+        svc.handle_utterance(_utterance_msg(sess2, "my secret is s2-token"))
+        svc.handle_speak(_speak_msg(sess2, "acknowledged s2-token"))
+
+        persona = svc.personas[svc.default_persona]
+        assert persona.memory is not None, "default short-term memory must always be available"
+
+        h1 = [m.content for m in persona.memory.get_history("s1")]
+        h2 = [m.content for m in persona.memory.get_history("s2")]
+
+        assert "my secret is s1-token" in h1 and "acknowledged s1-token" in h1
+        assert "my secret is s2-token" in h2 and "acknowledged s2-token" in h2
+        # no cross-contamination between sessions
+        assert all("s2-token" not in c for c in h1), f"s2 leaked into s1: {h1}"
+        assert all("s1-token" not in c for c in h2), f"s1 leaked into s2: {h2}"
+        # an unknown session has no memory
+        assert persona.memory.get_history("never-seen") == []
+
+    def test_memory_isolated_across_distinct_personas(self, svc):
+        """Different personas summoned per session keep memory in separate stores."""
+        sess1 = SessionManager.sessions["s1"]
+        sess2 = SessionManager.sessions["s2"]
+        svc.handle_persona_summon(_summon_msg(sess1, "Alice"))
+        svc.handle_persona_summon(_summon_msg(sess2, "Bob"))
+
+        svc.handle_utterance(_utterance_msg(sess1, "this is for Alice"))
+        svc.handle_utterance(_utterance_msg(sess2, "this is for Bob"))
+
+        alice = svc.personas["Alice"]
+        bob = svc.personas["Bob"]
+        assert "this is for Alice" in [m.content for m in alice.memory.get_history("s1")]
+        assert "this is for Bob" in [m.content for m in bob.memory.get_history("s2")]
+        # Alice never saw s2's turn; Bob never saw s1's
+        assert alice.memory.get_history("s2") == []
+        assert bob.memory.get_history("s1") == []

--- a/test/test_session_e2e.py
+++ b/test/test_session_e2e.py
@@ -1,0 +1,173 @@
+"""End-to-end tests for per-session persona isolation (PR #140).
+
+PersonaService keeps independent state per session:
+  - active_personas: {session_id -> persona name}
+  - active_personas: {session_id -> persona name}
+
+All tests drive the real PersonaService handlers through a FakeBus;
+no network access or LLM downloads are required (ovos-solver-failure-plugin only).
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+from ovos_utils.fakebus import FakeBus
+
+from ovos_persona import PersonaService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _persona_dir(*names):
+    """Return a temp directory populated with minimal persona JSON files."""
+    tmpdir = tempfile.mkdtemp()
+    for name in names:
+        with open(os.path.join(tmpdir, f"{name}.json"), "w") as fh:
+            json.dump({"name": name, "solvers": ["ovos-solver-failure-plugin"]}, fh)
+    return tmpdir
+
+
+def _msg(session: Session, msg_type: str = "test", data: dict = None) -> Message:
+    """Build a Message carrying the given session context."""
+    return Message(msg_type, data or {}, {"session": session.serialize()})
+
+
+def _summon_msg(session: Session, persona_name: str) -> Message:
+    return _msg(session, "persona:summon", {"persona": persona_name})
+
+
+def _release_msg(session: Session, persona_name: str) -> Message:
+    return _msg(session, "persona:release", {"persona": persona_name})
+
+
+def _utterance_msg(session: Session, utterance: str) -> Message:
+    return _msg(session, "recognizer_loop:utterance", {"utterances": [utterance]})
+
+
+def _speak_msg(session: Session, utterance: str) -> Message:
+    return _msg(session, "speak", {"utterance": utterance})
+
+
+# ---------------------------------------------------------------------------
+# Fixture: service with two named personas (Alice, Bob) + no plugin personas
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def svc():
+    personas_path = _persona_dir("Alice", "Bob")
+    service = PersonaService(
+        bus=FakeBus(),
+        config={
+            "personas_path": personas_path,
+            "ignore_plugin_personas": True,
+            "default_persona": "Alice",
+            "short-term-memory": True,
+        },
+    )
+    assert "Alice" in service.personas, "Alice persona must be loaded"
+    assert "Bob" in service.personas, "Bob persona must be loaded"
+    return service
+
+
+@pytest.fixture(autouse=True)
+def fresh_sessions(svc):
+    """Reset per-session state between tests so tests are independent."""
+    svc.active_personas.clear()
+    svc._active_sessions.clear()
+    # Re-register sessions in the global SessionManager
+    for sid in ("s1", "s2"):
+        sess = Session(session_id=sid)
+        SessionManager.sessions[sid] = sess
+    yield
+    svc.active_personas.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestIndependentActivePersonas:
+    """Summoning a persona in one session must not affect another."""
+
+    def test_independent_summon(self, svc):
+        sess1 = SessionManager.sessions["s1"]
+        sess2 = SessionManager.sessions["s2"]
+
+        svc.handle_persona_summon(_summon_msg(sess1, "Alice"))
+        svc.handle_persona_summon(_summon_msg(sess2, "Bob"))
+
+        msg_s1 = _msg(sess1)
+        msg_s2 = _msg(sess2)
+
+        assert svc.get_active_persona(msg_s1) == "Alice"
+        assert svc.get_active_persona(msg_s2) == "Bob"
+
+    def test_activating_second_session_does_not_overwrite_first(self, svc):
+        sess1 = SessionManager.sessions["s1"]
+        sess2 = SessionManager.sessions["s2"]
+
+        svc.handle_persona_summon(_summon_msg(sess1, "Alice"))
+        # Summon a different persona on s2
+        svc.handle_persona_summon(_summon_msg(sess2, "Bob"))
+
+        # s1 still has Alice
+        assert svc.get_active_persona(_msg(sess1)) == "Alice"
+
+
+class TestReleaseIsolation:
+    """Releasing a persona in one session must not affect others."""
+
+    def test_release_s1_leaves_s2_intact(self, svc):
+        sess1 = SessionManager.sessions["s1"]
+        sess2 = SessionManager.sessions["s2"]
+
+        svc.handle_persona_summon(_summon_msg(sess1, "Alice"))
+        svc.handle_persona_summon(_summon_msg(sess2, "Bob"))
+
+        # Release only s1
+        svc.handle_persona_release(_release_msg(sess1, "Alice"))
+
+        # s1 should have no session-scoped active persona
+        assert svc.get_active_persona(_msg(sess1), include_default=False) is None
+        # s2 must still have Bob
+        assert svc.get_active_persona(_msg(sess2), include_default=False) == "Bob"
+
+
+class TestExplicitOverride:
+    """A persona name in message.data must override the session-scoped one."""
+
+    def test_explicit_persona_in_data_wins(self, svc):
+        sess1 = SessionManager.sessions["s1"]
+
+        # Summon Alice as the session persona
+        svc.handle_persona_summon(_summon_msg(sess1, "Alice"))
+
+        # Build a message that explicitly requests Bob
+        override_msg = _msg(sess1, "test", {"persona": "Bob"})
+        resolved = svc.get_active_persona(override_msg)
+
+        assert resolved == "Bob", (
+            f"Expected explicit override 'Bob', got '{resolved}'"
+        )
+
+
+class TestDefaultFallback:
+    """Sessions with no active persona fall back to the configured default."""
+
+    def test_returns_default_when_include_default_true(self, svc):
+        # s1 has no session-scoped persona
+        sess1 = SessionManager.sessions["s1"]
+        persona = svc.get_active_persona(_msg(sess1), include_default=True)
+        # The fixture configures default_persona = "Alice"
+        assert persona == "Alice"
+
+    def test_returns_none_when_include_default_false(self, svc):
+        sess1 = SessionManager.sessions["s1"]
+        persona = svc.get_active_persona(_msg(sess1), include_default=False)
+        assert persona is None

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -1,6 +1,7 @@
 """Smoke tests — verify the package imports and ships its pipeline plugin
 entry-point (and no longer the bundled HiveMind agent plugin)."""
 from importlib.metadata import entry_points
+from unittest.mock import patch, MagicMock
 
 
 def test_package_imports():
@@ -62,3 +63,67 @@ def test_basic_short_term_memory_merge_consecutive_assistant():
     assert len(assistant_msgs) == 1
     assert "part one" in assistant_msgs[0].content
     assert "part two" in assistant_msgs[0].content
+def test_per_session_active_personas_attribute():
+    """PersonaService tracks active personas per session (not a single global)."""
+    from ovos_persona import PersonaService
+    from ovos_utils.fakebus import FakeBus
+
+    with patch("ovos_persona.PersonaService.load_personas"), \
+         patch("ovos_persona.PersonaService.load_intent_files"), \
+         patch("ovos_persona.OVOSAbstractApplication.__init__"), \
+         patch("ovos_persona.ConfidenceMatcherPipeline.__init__"), \
+         patch.object(PersonaService, "add_event"):
+        svc = PersonaService.__new__(PersonaService)
+        svc.config = {}
+        svc.message_history = {}
+        svc.active_personas = {}
+        svc.personas = {}
+        svc.intent_matchers = {}
+        svc.blacklist = []
+        svc._active_sessions = {}
+
+    assert hasattr(svc, "active_personas"), "active_personas dict must exist"
+    assert hasattr(svc, "message_history"), "message_history dict must exist"
+    assert not hasattr(svc, "active_persona") or isinstance(
+        getattr(svc, "active_persona", None), type(None)
+    ), "legacy single active_persona should not exist as a non-None attribute"
+    assert isinstance(svc.active_personas, dict)
+    assert isinstance(svc.message_history, dict)
+
+
+def test_per_session_isolation():
+    """Active persona set for session A must not bleed into session B."""
+    from ovos_persona import PersonaService
+
+    svc = PersonaService.__new__(PersonaService)
+    svc.active_personas = {}
+
+    sess_a = "session-a"
+    sess_b = "session-b"
+
+    svc.active_personas[sess_a] = "AssistantA"
+    # session B is untouched
+    assert svc.active_personas.get(sess_b) is None
+    assert svc.active_personas[sess_a] == "AssistantA"
+
+    # releasing session A does not affect B
+    svc.active_personas.pop(sess_a)
+    assert sess_a not in svc.active_personas
+
+
+def test_message_history_per_session():
+    """Message history is tracked independently per session."""
+    from ovos_persona import PersonaService
+
+    svc = PersonaService.__new__(PersonaService)
+    svc.message_history = {}
+
+    sess_a = "session-a"
+    sess_b = "session-b"
+
+    svc.message_history.setdefault(sess_a, []).append(("user", "hello"))
+    svc.message_history.setdefault(sess_a, []).append(("ai", "hi there"))
+
+    assert sess_b not in svc.message_history
+    assert len(svc.message_history[sess_a]) == 2
+    assert svc.message_history[sess_a][0] == ("user", "hello")


### PR DESCRIPTION
track personas per Session

unblocks:
- different persona per wakeword
- different TTS per persona
- different persona for each hivemind satellite

~~needs https://github.com/OpenVoiceOS/ovos-bus-client/pull/192~~
**ovos-bus-client PR #192 (feat: persona_id) was merged 2026-01-23 and is released as v1.5.0 — dependency unblocked.**

## How to test

```python
from ovos_persona import PersonaService
from ovos_utils.fakebus import FakeBus

svc = PersonaService(bus=FakeBus())

# Simulate summon for session A
svc.active_personas["session-a"] = "MyPersona"
assert svc.active_personas.get("session-b") is None  # isolation

# Simulate message history tracking
svc.message_history["session-a"] = [("user", "hello"), ("ai", "hi")]
assert "session-b" not in svc.message_history

# Release session A
svc.active_personas.pop("session-a")
assert "session-a" not in svc.active_personas
```

Run the unit tests:
```
pip install -e ".[test]"
pytest test/test_smoke.py -v
# Expected: 6 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Personas are now managed independently per conversation session, allowing different personas to be active simultaneously across concurrent conversations.
  * Implemented fuzzy matching for persona names to reduce misclassifications.

* **Documentation**
  * Updated documentation to clarify per-session conversation memory isolation and default short-term memory availability.

* **Tests**
  * Added comprehensive end-to-end and session isolation test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->