### PR TITLE
fix: can stop

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -562,6 +562,10 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.speak_dialog("release_persona", {"persona": self.active_persona})
         self.active_persona = None
 
+    def can_stop(self, message: Message) -> bool:
+        sess = SessionManager.get(message)
+        return self._active_sessions.get(sess.session_id) or False
+        
     def stop_session(self, session: Session):
         if self._active_sessions.get(session.session_id):
             self._active_sessions[session.session_id] = False


### PR DESCRIPTION
required method from base class

```
2026-03-06 11:58:56.034 - skills - ovos_workshop.skills.ovos:on_error:2120 - ERROR - Error handling event 'persona.openvoiceos.stop.ping' : All skills that implement self.stop or self.stop_session must also implement self.can_stop.
2026-03-06 11:58:56.040 - persona.openvoiceos - ERROR - All skills that implement self.stop or self.stop_session must also implement self.can_stop.
Traceback (most recent call last):
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_utils/events.py", line 80, in wrapper
    handler(message)
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 1154, in _handle_stop_ack
    "can_handle": self.can_stop(message)},
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 267, in can_stop
    raise NotImplementedError("All skills that implement self.stop or self.stop_session must also implement self.can_stop.")
NotImplementedError: All skills that implement self.stop or self.stop_session must also implement self.can_stop.
2026-03-06 11:58:56.535 - skills - ovos_core.intent_services.service:handle_utterance:471 - INFO - ovos-stop-pipeline-plugin match (en-US): IntentHandlerMatch(match_type='stop:skill', match_data={'conf': 0.629, 'skill_id': 'persona.openvoiceos'}, skill_id='stop.openvoiceos', utterance='what are you', updated_session=<ovos_bus_client.session.Session object at 0x7f4fc44a10>)
2026-03-06 12:06:39.601 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 12:21:39.522 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 12:36:39.440 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 12:51:39.354 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 13:06:39.778 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 13:21:39.688 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 13:36:39.604 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 13:51:39.510 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 14:06:39.448 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 14:21:39.505 - skills - skill_ovos_homescreen:update_examples:224 - WARNING - no utterance examples registered with homescreen
2026-03-06 14:27:53.432 - skills - ovos_core.intent_services.service:handle_utterance:450 - INFO - Parsing utterance: ['what are you']
2026-03-06 14:27:53.449 - skills - ovos_workshop.skills.ovos:on_error:2120 - ERROR - Error handling event 'persona.openvoiceos.stop.ping' : All skills that implement self.stop or self.stop_session must also implement self.can_stop.
2026-03-06 14:27:53.454 - persona.openvoiceos - ERROR - All skills that implement self.stop or self.stop_session must also implement self.can_stop.
Traceback (most recent call last):
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_utils/events.py", line 80, in wrapper
    handler(message)
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 1154, in _handle_stop_ack
    "can_handle": self.can_stop(message)},
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 267, in can_stop
    raise NotImplementedError("All skills that implement self.stop or self.stop_session must also implement self.can_stop.")
NotImplementedError: All skills that implement self.stop or self.stop_session must also implement self.can_stop.
2026-03-06 14:27:53.956 - skills - ovos_core.intent_services.service:handle_utterance:471 - INFO - ovos-stop-pipeline-plugin match (en-US): IntentHandlerMatch(match_type='stop:skill', match_data={'conf': 0.629, 'skill_id': 'stop.openvoiceos'}, skill_id='stop.openvoiceos', utterance='what are you', updated_session=<ovos_bus_client.session.Session object at 0x7f4f698a50>)
2026-03-06 14:28:01.072 - skills - ovos_core.intent_services.service:handle_utterance:450 - INFO - Parsing utterance: ['what time is it']
2026-03-06 14:28:01.128 - skills - ovos_workshop.skills.ovos:on_error:2120 - ERROR - Error handling event 'persona.openvoiceos.stop.ping' : All skills that implement self.stop or self.stop_session must also implement self.can_stop.
2026-03-06 14:28:01.131 - persona.openvoiceos - ERROR - All skills that implement self.stop or self.stop_session must also implement self.can_stop.
Traceback (most recent call last):
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_utils/events.py", line 80, in wrapper
    handler(message)
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 1154, in _handle_stop_ack
    "can_handle": self.can_stop(message)},
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/goldyfruit/.venvs/ovos/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 267, in can_stop
    raise NotImplementedError("All skills that implement self.stop or self.stop_session must also implement self.can_stop.")
NotImplementedError: All skills that implement self.stop or self.stop_session must also implement self.can_stop.
2026-03-06 14:28:01.583 - skills - ovos_core.intent_services.service:handle_utterance:471 - INFO - ovos-stop-pipeline-plugin match (en-US): IntentHandlerMatch(match_type='stop:skill', match_data={'conf': 0.532, 'skill_id': 'stop.openvoiceos'}, skill_id='stop.openvoiceos', utterance='what time is it', updated_session=<ovos_bus_client.session.Session object at 0x7f4f5d4310>)

``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new capability to check if an active persona interaction can be stopped. This feature enhances session management by providing visibility into the current stop-state of ongoing interactions. Users and administrators now have better control and monitoring capabilities for active engagement sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->