### PR TITLE
Add missing French persona vocab

### DIFF
--- a/ovos_persona/locale/fr/Release.voc
+++ b/ovos_persona/locale/fr/Release.voc
@@ -1,12 +1,8 @@
-(arrêter|arrête) (de discuter|de communiquer|de répondre|de parler)
-(arrêter|arrête) (la|le) (chat|interaction|conversation|discussion|dialogue)
-(désactiver|désactive|éteindre|éteins) (chat|chatbot|persona|IA|LLM|Large Language Model|)
-(ferme ta bouche|ferme-la)
-(finir|finis|fermer|ferme|stop|arrêter|arrête|sortir de|sors de|quitter|quitte|abandonner|abandonne|terminer|termine|interrompre|interromps|désactiver|désactive) [le|la] (chat|chatbot|persona|IA|LLM|Large Language Model|interaction|conversation|discussion|dialogue)
-(pars|va) (en hibernation|dormir|dans la tombe)
-(retirer|retire|supprimer|supprimer|arrêter|arrête|terminer|termine) (chat|chatbot|persona|IA|LLM|Large Language Model|)
-assez (parlé|discuté)
-au revoir
+(arrête|arrêter|stop) (de parler|de répondre|de discuter)
+(désactive|désactiver|arrête|arrêter|quitte|quitter|ferme|fermer|stop) [la|le] (persona|personnalité|chatbot|assistant|IA|interaction|conversation|discussion)
+(mets|mettre) (la persona|la personnalité|le chatbot|l'assistant|l'IA) en veille
+(éteins|éteindre) [la|le] (persona|personnalité|chatbot|assistant|IA)
+assez parlé
 au revoir
 laisse-moi tranquille
-mettre (chatbot|persona|IA|LLM) en sommeil
+tais-toi

--- a/ovos_persona/locale/fr/activated_persona.dialog
+++ b/ovos_persona/locale/fr/activated_persona.dialog
@@ -1,5 +1,5 @@
 J'ai activé {persona}.
-Vous parlez maintenant à {persona}.
+Vous parlez maintenant avec {persona}.
 {persona} est désormais en ligne.
 {persona} est maintenant active.
 {persona} est opérationnelle.

--- a/ovos_persona/locale/fr/activated_persona.dialog
+++ b/ovos_persona/locale/fr/activated_persona.dialog
@@ -1,14 +1,6 @@
-{persona} a été activée.
-{persona} a été activée.
-{persona} a été activée.
-{persona} a été initialisée.
-{persona} activée
-{persona} activée
-{persona} est désormais active.
-{persona} est désormais activée
+J'ai activé {persona}.
+Vous parlez maintenant à {persona}.
 {persona} est désormais en ligne.
-{persona} est désormais entièrement activée.
-{persona} est désormais opérationnelle.
-{persona} est maintenant activée.
-{persona} est maintenant en ligne.
-{persona} est maintenant prête.
+{persona} est maintenant active.
+{persona} est opérationnelle.
+{persona} est prête.

--- a/ovos_persona/locale/fr/active_persona.dialog
+++ b/ovos_persona/locale/fr/active_persona.dialog
@@ -1,5 +1,5 @@
 J'utilise actuellement {persona}.
-La persona en cours est {persona}.
 La personnalité active est {persona}.
+La personnalité en cours est {persona}.
 Vous parlez actuellement à {persona}.
 {persona} est la personnalité active.

--- a/ovos_persona/locale/fr/active_persona.dialog
+++ b/ovos_persona/locale/fr/active_persona.dialog
@@ -1,6 +1,5 @@
-Actuellement, la personnalité active est {persona}
-Actuellement, la personnalité active est {persona}
-J'utilise actuellement {persona} pour interagir avec vous
-La personnalité active est {persona}
-Le persona actuellement utilisé est {persona}
-Vous parlez actuellement à {persona}
+J'utilise actuellement {persona}.
+La persona en cours est {persona}.
+La personnalité active est {persona}.
+Vous parlez actuellement à {persona}.
+{persona} est la personnalité active.

--- a/ovos_persona/locale/fr/active_persona.intent
+++ b/ovos_persona/locale/fr/active_persona.intent
@@ -1,10 +1,7 @@
-(Quel|Quelle) (persona|personnalité) est (en cours d'exécution|en train de parler|actif|active|activé|activée) (maintenant|en ce moment|)
-(Quel|Quelle) (persona|personnalité) est actuellement (actif|activée|activé|active)
-(qui|quelle personnalité) est (actif|active)
-(qui|quelle|quel) est (le persona|la personnalité) (actif|active)
-(à qui|à quel persona|à quelle personnalité) je parle (maintenant|en ce moment|actuellement|)
-Est-ce que je parle à (un persona|une personnalité)
-Parle-moi (du persona|de la personnalité) (actif|active)
-Qui est actuellement (active|activée|actif|activé)
-Y a-t-il (un persona|une personnalité) (actif|active)
-active (le persona|la personnalité)
+(quel|quelle) (persona|personnalité) est (active|activée) (en ce moment|actuellement|)
+(qui|quelle personnalité) est (active|activée)
+(à qui|avec qui) est-ce que je parle (en ce moment|actuellement|)
+parle-moi de (la persona|de la personnalité) active
+quelle est (la persona|la personnalité) active
+qui me répond (en ce moment|actuellement|)
+y a-t-il (une persona|une personnalité) active

--- a/ovos_persona/locale/fr/ask.intent
+++ b/ovos_persona/locale/fr/ask.intent
@@ -2,7 +2,7 @@
 (demander|demande) à {persona} (son|sa|ses|) (analyse|commentaire|impression|interprétation|perception|réaction|point de vue|pensées|compréhension) (sur|de|à propos de) {utterance}
 (demander|demande) à {persona} ce qu'(il|elle) (a à dire|pense) (sur|de|à propos de) {utterance}
 (demander|demande) à {persona} {utterance}
+(sonde|demande|interroge|pose la question à) {persona} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}
 (sonde|demande|interroge|pose la question à) {persona} (sur|de|à propos de) {utterance}
 (sonde|demande|interroge|pose la question à) {persona} pour connaître son point de vue sur {utterance}
-(sonde|demande|interroge|pose la question à) {personne} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}
 que (pense|dit) {persona} (sur|de|à propos de) {utterance}

--- a/ovos_persona/locale/fr/ask.intent
+++ b/ovos_persona/locale/fr/ask.intent
@@ -1,8 +1,7 @@
-(demander|demande) à {persona} (de partager|) son (point de vue|opinion) (à propos de|sur) {utterance}
-(demander|demande) à {persona} (son|sa|ses|) (analyse|commentaire|impression|interprétation|perception|réaction|point de vue|pensées|compréhension) (sur|de|à propos de) {utterance}
-(demander|demande) à {persona} ce qu'(il|elle) (a à dire|pense) (sur|de|à propos de) {utterance}
-(demander|demande) à {persona} {utterance}
-(sonde|demande|interroge|pose la question à) {persona} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}
-(sonde|demande|interroge|pose la question à) {persona} (sur|de|à propos de) {utterance}
-(sonde|demande|interroge|pose la question à) {persona} pour connaître son point de vue sur {utterance}
-que (pense|dit) {persona} (sur|de|à propos de) {utterance}
+(demande|demander) à {persona} ce (qu'il|qu'elle) a à dire sur {utterance}
+(demande|demander) à {persona} ce (qu'il|qu'elle) pense de {utterance}
+(demande|demander) à {persona} de réagir à {utterance}
+(demande|demander) à {persona} son (avis|point de vue|analyse) sur {utterance}
+(interroge|interroger|questionne|questionner) {persona} au sujet de {utterance}
+(pose|poser) une question à {persona} au sujet de {utterance}
+que (pense|dit) {persona} de {utterance}

--- a/ovos_persona/locale/fr/ask.intent
+++ b/ovos_persona/locale/fr/ask.intent
@@ -1,7 +1,7 @@
-(demande|demander) à {persona} ce (qu'il|qu'elle) a à dire sur {utterance}
-(demande|demander) à {persona} ce (qu'il|qu'elle) pense de {utterance}
-(demande|demander) à {persona} de réagir à {utterance}
-(demande|demander) à {persona} son (avis|point de vue|analyse) sur {utterance}
-(interroge|interroger|questionne|questionner) {persona} au sujet de {utterance}
-(pose|poser) une question à {persona} au sujet de {utterance}
+demande à {persona} ce (qu'il|qu'elle) a à dire sur {utterance}
+demande à {persona} ce (qu'il|qu'elle) pense de {utterance}
+demande à {persona} de réagir à {utterance}
+demande à {persona} son (avis|point de vue|analyse) sur {utterance}
+interroge {persona} au sujet de {utterance}
+pose une question à {persona} au sujet de {utterance}
 que (pense|dit) {persona} de {utterance}

--- a/ovos_persona/locale/fr/ask.voc
+++ b/ovos_persona/locale/fr/ask.voc
@@ -1,0 +1,8 @@
+demande
+demander
+interroge
+interroger
+pose une question
+questionne
+questionner
+sollicite l'avis de

--- a/ovos_persona/locale/fr/ask.voc
+++ b/ovos_persona/locale/fr/ask.voc
@@ -2,7 +2,7 @@ demande
 demander
 interroge
 interroger
-pose une question
+pose une question à
 questionne
 questionner
 sollicite l'avis de

--- a/ovos_persona/locale/fr/list_personas.dialog
+++ b/ovos_persona/locale/fr/list_personas.dialog
@@ -1,3 +1,3 @@
 J'ai les personnalités suivantes.
-Les personas disponibles sont les suivantes.
+Les personnalités disponibles sont les suivantes.
 Voici les personas disponibles.

--- a/ovos_persona/locale/fr/list_personas.dialog
+++ b/ovos_persona/locale/fr/list_personas.dialog
@@ -1,3 +1,3 @@
-J'ai les personnalités suivantes
-Les personas disponibles sont
-Voici les personas disponibles
+J'ai les personnalités suivantes.
+Les personas disponibles sont les suivantes.
+Voici les personas disponibles.

--- a/ovos_persona/locale/fr/list_personas.intent
+++ b/ovos_persona/locale/fr/list_personas.intent
@@ -1,5 +1,5 @@
-(Peux-tu lister|Liste) les (personas|personnalités|LLM|LLMs|Large Language Models) [disponibles]
-(Quels|Quelles) (personas|personnalités|LLM|LLMs|Large Language Models) (puis-je utiliser|sont disponibles)
-(Qui|Quels|Quelles) sont les [personas|personnalités|LLM|LLMs|Large Language Models] [disponibles]
-Donne-moi une liste de [personas|persona|personnalités|LLM|LLMs|Large Language Models] [disponibles|disponible]
-Parle-moi des (personas|personnalités|LLM|LLMs|Large Language Models) disponibles
+(peux-tu lister|liste) les (personas|personnalités) [disponibles]
+(quelles|quels) (personas|personnalités) (puis-je utiliser|sont disponibles)
+(qui|quels|quelles) sont les (personas|personnalités) disponibles
+donne-moi la liste des (personas|personnalités) [disponibles]
+parle-moi des (personas|personnalités) disponibles

--- a/ovos_persona/locale/fr/no_active_persona.dialog
+++ b/ovos_persona/locale/fr/no_active_persona.dialog
@@ -1,4 +1,4 @@
-Aucune persona n'est active pour l'instant. J'utilise ma personnalité de base.
+Aucune personnalité n'est active pour l'instant. J'utilise ma personnalité de base.
 Aucune personnalité n'est active pour le moment. Je réponds avec ma personnalité par défaut.
-Il n'y a pas de persona active pour le moment.
+Il n'y a pas de personnalité active pour le moment.
 Je n'ai trouvé aucune personnalité active. Je vous réponds donc normalement.

--- a/ovos_persona/locale/fr/no_active_persona.dialog
+++ b/ovos_persona/locale/fr/no_active_persona.dialog
@@ -1,6 +1,4 @@
-Actuellement, aucune personnalité n'est activée, vous me parlerez donc en tant que personnalité de base.
-Aucune personnalité active, j'utilise ma personnalité de base
-Aucune personnalité n'est active pour le moment. J'utilise ma personnalité de base pour interagir avec vous
-Comme aucune personnalité n’est active, je continuerai à utiliser ma personnalité par défaut pour le moment
-Il semble qu'il n'y ait pas de personas actifs pour le moment, je répondrai donc en tant que moi-même
-Je n'ai trouvé aucune personnalité active, donc j'interagirai avec vous en tant que moi par défaut
+Aucune persona n'est active pour l'instant. J'utilise ma personnalité de base.
+Aucune personnalité n'est active pour le moment. Je réponds avec ma personnalité par défaut.
+Il n'y a pas de persona active pour le moment.
+Je n'ai trouvé aucune personnalité active. Je vous réponds donc normalement.

--- a/ovos_persona/locale/fr/no_personas.dialog
+++ b/ovos_persona/locale/fr/no_personas.dialog
@@ -1,4 +1,4 @@
 Aucune personnalité n'est disponible pour le moment.
-Désolé, aucune persona n'est disponible actuellement.
+Désolé, aucune personnalité n'est disponible actuellement.
 Il n'y a pas de personnalité avec laquelle interagir pour le moment.
-Je n'ai trouvé aucune persona disponible pour l'instant.
+Je n'ai trouvé aucune personnalité disponible pour l'instant.

--- a/ovos_persona/locale/fr/no_personas.dialog
+++ b/ovos_persona/locale/fr/no_personas.dialog
@@ -1,6 +1,4 @@
-Désolé, je n'ai trouvé aucune personnalité pour le moment
-Il n'y a aucune personnalité avec laquelle interagir pour le moment
-Il semble qu'aucune personnalité ne soit disponible pour interagir avec elle en ce moment
-Il semble qu'il n'y ait actuellement aucune personnalité disponible
-Je n'ai trouvé aucun persona pour le moment. Veuillez vérifier à nouveau plus tard
-Malheureusement, il n'y a pas de personas pour le moment
+Aucune personnalité n'est disponible pour le moment.
+Désolé, aucune persona n'est disponible actuellement.
+Il n'y a pas de personnalité avec laquelle interagir pour le moment.
+Je n'ai trouvé aucune persona disponible pour l'instant.

--- a/ovos_persona/locale/fr/opinion.voc
+++ b/ovos_persona/locale/fr/opinion.voc
@@ -1,0 +1,10 @@
+analyse
+avis
+commentaire
+impression
+interprétation
+pensées
+perception
+point de vue
+position
+réaction

--- a/ovos_persona/locale/fr/persona.voc
+++ b/ovos_persona/locale/fr/persona.voc
@@ -1,0 +1,14 @@
+IA
+IAs
+LLM
+LLMs
+agent
+assistant
+assistant virtuel
+assistante virtuelle
+bot
+chatbot
+grand modèle de langage
+persona
+personnalité
+personnalités

--- a/ovos_persona/locale/fr/persona.voc
+++ b/ovos_persona/locale/fr/persona.voc
@@ -10,5 +10,6 @@ bot
 chatbot
 grand modèle de langage
 persona
+personas
 personnalité
 personnalités

--- a/ovos_persona/locale/fr/persona_error.dialog
+++ b/ovos_persona/locale/fr/persona_error.dialog
@@ -1,10 +1,5 @@
-Il y a eu un dysfonctionnement lors de la conversation avec {persona}.
-Il y a eu un problème lors de la conversation avec {persona}.
-Nous avons rencontré une erreur lors de la discussion avec {persona}.
-Quelque chose s'est mal passé lors d'une conversation avec {persona}.
-Un problème est survenu lors d'une conversation avec {persona}.
-Un problème est survenu lors de la communication avec {persona}.
-Un problème est survenu lors de la conversation avec {persona}.
-Un problème technique est survenu lors d'une conversation avec {persona}.
-Une erreur s'est produite lors de l'interaction avec {persona}.
-Une erreur s'est produite lors de l'interaction avec {persona}.
+Je n'ai pas pu poursuivre la conversation avec {persona}.
+La conversation avec {persona} a rencontré une erreur.
+Quelque chose s'est mal passé avec {persona}.
+Un problème est survenu pendant la conversation avec {persona}.
+Une erreur s'est produite pendant mon échange avec {persona}.

--- a/ovos_persona/locale/fr/persona_select.dialog
+++ b/ovos_persona/locale/fr/persona_select.dialog
@@ -1,3 +1,3 @@
-Avec qui aimeriez-vous interagir ?
-Faites-moi savoir laquelle vous souhaitez activer
-Laquelle aimeriez-vous choisir
+Avec quelle personnalité voulez-vous interagir ?
+Laquelle voulez-vous utiliser ?
+Quelle personnalité voulez-vous activer ?

--- a/ovos_persona/locale/fr/persona_select.dialog
+++ b/ovos_persona/locale/fr/persona_select.dialog
@@ -1,3 +1,3 @@
-Avec quelle personnalité voulez-vous interagir ?
+Avec quelle personnalité voulez-vous discuter ?
 Laquelle voulez-vous utiliser ?
 Quelle personnalité voulez-vous activer ?

--- a/ovos_persona/locale/fr/release_persona.dialog
+++ b/ovos_persona/locale/fr/release_persona.dialog
@@ -1,14 +1,5 @@
-{persona} a été arrêtée.
-{persona} a été désactivée
-{persona} a été désactivée
-{persona} a été désactivée et n'est plus fonctionnelle.
-{persona} a été désactivée.
-{persona} a été désactivée.
+J'ai désactivé {persona}.
+Je n'utilise plus {persona}.
 {persona} a été mise hors tension.
-{persona} désactivée
-{persona} désactivée
-{persona} est désormais désactivée.
-{persona} est désormais inactive et désactivée.
-{persona} est désormais inactive.
+{persona} est maintenant désactivée.
 {persona} n'est plus active.
-{persona} n'est plus activée.

--- a/ovos_persona/locale/fr/release_persona.dialog
+++ b/ovos_persona/locale/fr/release_persona.dialog
@@ -1,5 +1,5 @@
 J'ai désactivé {persona}.
 Je n'utilise plus {persona}.
-{persona} a été mise hors tension.
+Je ne parle plus avec {persona}.
 {persona} est maintenant désactivée.
 {persona} n'est plus active.

--- a/ovos_persona/locale/fr/summon.intent
+++ b/ovos_persona/locale/fr/summon.intent
@@ -1,5 +1,5 @@
-(active|activer|réveille|réveiller) (la|le) {persona} (persona|personnalité|assistant|chatbot|agent|IA|)
-(active|activer|réveille|réveiller|invoque|invoquer) {persona}
+(active|réveille) (la|le) {persona} (persona|personnalité|assistant|chatbot|agent|IA|)
+(active|réveille|invoque) {persona}
 (connecte-moi|mets-moi en relation|je veux parler) (à|avec) {persona}
-(démarre|démarrer|ouvre|ouvrir|commence|commencer) (une|la) (conversation|discussion|interaction) avec {persona}
+(démarre|ouvre|commence) (une|la) (conversation|discussion|interaction) avec {persona}
 [laisse-moi] (parler|discuter|interagir) (avec|à) {persona}

--- a/ovos_persona/locale/fr/summon.intent
+++ b/ovos_persona/locale/fr/summon.intent
@@ -1,5 +1,5 @@
-(activer|active|accéder à|accède à|réveiller|réveille) (le|la) {persona} (virtuel|virtuelle) (IA|bot|persona|personnalité|agent|assistant|assistante|chatbot|)
-(connecte-moi|je veux parler) (à|avec) {persona}
-(démarrer|démarre|initier|initie|commencer|commence|entrer|entre|établir|établis) (un|une) (discussion|conversation|dialogue) avec {persona}
-(initier|initie|commencer|commence|ouvrir|ouvre) (un|une|) (chat|interaction|communication|conversation|discussion|dialogue) avec {persona}
-[laisse moi] (parler|chatter|interagir|discuter) (avec|à) {persona}
+(active|activer|réveille|réveiller) (la|le) {persona} (persona|personnalité|assistant|chatbot|agent|IA|)
+(active|activer|réveille|réveiller|invoque|invoquer) {persona}
+(connecte-moi|mets-moi en relation|je veux parler) (à|avec) {persona}
+(démarre|démarrer|ouvre|ouvrir|commence|commencer) (une|la) (conversation|discussion|interaction) avec {persona}
+[laisse-moi] (parler|discuter|interagir) (avec|à) {persona}

--- a/ovos_persona/locale/fr/summon.voc
+++ b/ovos_persona/locale/fr/summon.voc
@@ -1,4 +1,4 @@
-(activer|active|réveiller|réveille|invoquer|invoque|appeler|appelle)
-(connecte-moi|je veux parler) (à|avec)
-(démarrer|démarre|initier|initie|commencer|commence|ouvrir|ouvre) (un|une) (chat|discussion|conversation|dialogue)
-[laisse-moi] (parler|chatter|interagir|discuter) (avec|à)
+(active|activer|réveille|réveiller|invoque|invoquer|appelle|appeler)
+(connecte-moi|mets-moi en relation|je veux parler) (à|avec)
+(démarre|démarrer|ouvre|ouvrir|commence|commencer) (une|la) (conversation|discussion|interaction)
+[laisse-moi] (parler|discuter|interagir) (avec|à)

--- a/ovos_persona/locale/fr/summon.voc
+++ b/ovos_persona/locale/fr/summon.voc
@@ -1,0 +1,4 @@
+(activer|active|réveiller|réveille|invoquer|invoque|appeler|appelle)
+(connecte-moi|je veux parler) (à|avec)
+(démarrer|démarre|initier|initie|commencer|commence|ouvrir|ouvre) (un|une) (chat|discussion|conversation|dialogue)
+[laisse-moi] (parler|chatter|interagir|discuter) (avec|à)

--- a/ovos_persona/locale/fr/unknown_persona.dialog
+++ b/ovos_persona/locale/fr/unknown_persona.dialog
@@ -1,10 +1,5 @@
-Je n'ai aucune idée de qui est {persona}.
-Je n'ai pas entendu parler de {persona}.
-Je ne connais pas {persona}
-Je ne connais pas {persona}.
+Je n'ai trouvé aucune personnalité nommée {persona}.
 Je ne connais pas {persona}.
 Je ne reconnais pas {persona}.
-Je ne sais pas qui est censée être {persona}.
-Je ne sais pas qui est {persona}
-Je ne suis pas sûr de qui est {persona}.
+Je ne sais pas qui est {persona}.
 {persona} m'est inconnue.

--- a/translations/fr/dialogs.json
+++ b/translations/fr/dialogs.json
@@ -11,25 +11,25 @@
     "La personnalité active est {persona}.",
     "Vous parlez actuellement à {persona}.",
     "J'utilise actuellement {persona}.",
-    "La persona en cours est {persona}.",
+    "La personnalité en cours est {persona}.",
     "{persona} est la personnalité active."
   ],
   "list_personas.dialog": [
     "Voici les personas disponibles.",
     "J'ai les personnalités suivantes.",
-    "Les personas disponibles sont les suivantes."
+    "Les personnalités disponibles sont les suivantes."
   ],
   "no_active_persona.dialog": [
     "Aucune personnalité n'est active pour le moment. Je réponds avec ma personnalité par défaut.",
-    "Aucune persona n'est active pour l'instant. J'utilise ma personnalité de base.",
+    "Aucune personnalité n'est active pour l'instant. J'utilise ma personnalité de base.",
     "Je n'ai trouvé aucune personnalité active. Je vous réponds donc normalement.",
-    "Il n'y a pas de persona active pour le moment."
+    "Il n'y a pas de personnalité active pour le moment."
   ],
   "no_personas.dialog": [
     "Aucune personnalité n'est disponible pour le moment.",
-    "Je n'ai trouvé aucune persona disponible pour l'instant.",
+    "Je n'ai trouvé aucune personnalité disponible pour l'instant.",
     "Il n'y a pas de personnalité avec laquelle interagir pour le moment.",
-    "Désolé, aucune persona n'est disponible actuellement."
+    "Désolé, aucune personnalité n'est disponible actuellement."
   ],
   "persona_error.dialog": [
     "Un problème est survenu pendant la conversation avec {persona}.",

--- a/translations/fr/dialogs.json
+++ b/translations/fr/dialogs.json
@@ -1,92 +1,60 @@
 {
   "activated_persona.dialog": [
-    "{persona} activée",
-    "{persona} activée",
-    "{persona} a été activée.",
-    "{persona} a été activée.",
-    "{persona} a été initialisée.",
-    "{persona} a été activée.",
-    "{persona} est maintenant activée.",
-    "{persona} est désormais active.",
-    "{persona} est désormais activée",
-    "{persona} est désormais entièrement activée.",
-    "{persona} est maintenant en ligne.",
+    "J'ai activé {persona}.",
+    "{persona} est maintenant active.",
+    "{persona} est prête.",
+    "Vous parlez maintenant à {persona}.",
     "{persona} est désormais en ligne.",
-    "{persona} est maintenant prête.",
-    "{persona} est désormais opérationnelle."
+    "{persona} est opérationnelle."
   ],
   "active_persona.dialog": [
-    "Actuellement, la personnalité active est {persona}",
-    "J'utilise actuellement {persona} pour interagir avec vous",
-    "Actuellement, la personnalité active est {persona}",
-    "La personnalité active est {persona}",
-    "Le persona actuellement utilisé est {persona}",
-    "Vous parlez actuellement à {persona}"
+    "La personnalité active est {persona}.",
+    "Vous parlez actuellement à {persona}.",
+    "J'utilise actuellement {persona}.",
+    "La persona en cours est {persona}.",
+    "{persona} est la personnalité active."
   ],
   "list_personas.dialog": [
-    "Voici les personas disponibles",
-    "J'ai les personnalités suivantes",
-    "Les personas disponibles sont"
+    "Voici les personas disponibles.",
+    "J'ai les personnalités suivantes.",
+    "Les personas disponibles sont les suivantes."
   ],
   "no_active_persona.dialog": [
-    "Actuellement, aucune personnalité n'est activée, vous me parlerez donc en tant que personnalité de base.",
-    "Je n'ai trouvé aucune personnalité active, donc j'interagirai avec vous en tant que moi par défaut",
-    "Il semble qu'il n'y ait pas de personas actifs pour le moment, je répondrai donc en tant que moi-même",
-    "Aucune personnalité active, j'utilise ma personnalité de base",
-    "Aucune personnalité n'est active pour le moment. J'utilise ma personnalité de base pour interagir avec vous",
-    "Comme aucune personnalité n’est active, je continuerai à utiliser ma personnalité par défaut pour le moment"
+    "Aucune personnalité n'est active pour le moment. Je réponds avec ma personnalité par défaut.",
+    "Aucune persona n'est active pour l'instant. J'utilise ma personnalité de base.",
+    "Je n'ai trouvé aucune personnalité active. Je vous réponds donc normalement.",
+    "Il n'y a pas de persona active pour le moment."
   ],
   "no_personas.dialog": [
-    "Je n'ai trouvé aucun persona pour le moment. Veuillez vérifier à nouveau plus tard",
-    "Il semble qu'il n'y ait actuellement aucune personnalité disponible",
-    "Il semble qu'aucune personnalité ne soit disponible pour interagir avec elle en ce moment",
-    "Désolé, je n'ai trouvé aucune personnalité pour le moment",
-    "Il n'y a aucune personnalité avec laquelle interagir pour le moment",
-    "Malheureusement, il n'y a pas de personas pour le moment"
+    "Aucune personnalité n'est disponible pour le moment.",
+    "Je n'ai trouvé aucune persona disponible pour l'instant.",
+    "Il n'y a pas de personnalité avec laquelle interagir pour le moment.",
+    "Désolé, aucune persona n'est disponible actuellement."
   ],
   "persona_error.dialog": [
-    "Un problème est survenu lors de la conversation avec {persona}.",
-    "Un problème est survenu lors d'une conversation avec {persona}.",
-    "Un problème technique est survenu lors d'une conversation avec {persona}.",
-    "Une erreur s'est produite lors de l'interaction avec {persona}.",
-    "Un problème est survenu lors de la communication avec {persona}.",
-    "Quelque chose s'est mal passé lors d'une conversation avec {persona}.",
-    "Une erreur s'est produite lors de l'interaction avec {persona}.",
-    "Il y a eu un dysfonctionnement lors de la conversation avec {persona}.",
-    "Il y a eu un problème lors de la conversation avec {persona}.",
-    "Nous avons rencontré une erreur lors de la discussion avec {persona}."
+    "Un problème est survenu pendant la conversation avec {persona}.",
+    "Une erreur s'est produite pendant mon échange avec {persona}.",
+    "Je n'ai pas pu poursuivre la conversation avec {persona}.",
+    "Quelque chose s'est mal passé avec {persona}.",
+    "La conversation avec {persona} a rencontré une erreur."
   ],
   "persona_select.dialog": [
-    "Faites-moi savoir laquelle vous souhaitez activer",
-    "Laquelle aimeriez-vous choisir",
-    "Avec qui aimeriez-vous interagir ?"
+    "Quelle personnalité voulez-vous activer ?",
+    "Avec quelle personnalité voulez-vous interagir ?",
+    "Laquelle voulez-vous utiliser ?"
   ],
   "release_persona.dialog": [
-    "{persona} désactivée",
-    "{persona} désactivée",
-    "{persona} a été désactivée",
-    "{persona} a été désactivée",
-    "{persona} a été désactivée et n'est plus fonctionnelle.",
-    "{persona} a été désactivée.",
-    "{persona} a été mise hors tension.",
-    "{persona} a été arrêtée.",
-    "{persona} a été désactivée.",
+    "J'ai désactivé {persona}.",
+    "{persona} est maintenant désactivée.",
+    "Je n'utilise plus {persona}.",
     "{persona} n'est plus active.",
-    "{persona} n'est plus activée.",
-    "{persona} est désormais désactivée.",
-    "{persona} est désormais inactive et désactivée.",
-    "{persona} est désormais inactive."
+    "{persona} a été mise hors tension."
   ],
   "unknown_persona.dialog": [
-    "Je ne sais pas qui est {persona}",
-    "Je ne connais pas {persona}",
-    "Je ne sais pas qui est censée être {persona}.",
+    "Je ne connais pas {persona}.",
     "Je ne reconnais pas {persona}.",
-    "Je n'ai aucune idée de qui est {persona}.",
-    "Je n'ai pas entendu parler de {persona}.",
-    "Je ne connais pas {persona}.",
-    "Je ne suis pas sûr de qui est {persona}.",
-    "Je ne connais pas {persona}.",
-    "{persona} m'est inconnue."
+    "{persona} m'est inconnue.",
+    "Je ne sais pas qui est {persona}.",
+    "Je n'ai trouvé aucune personnalité nommée {persona}."
   ]
 }

--- a/translations/fr/dialogs.json
+++ b/translations/fr/dialogs.json
@@ -3,7 +3,7 @@
     "J'ai activé {persona}.",
     "{persona} est maintenant active.",
     "{persona} est prête.",
-    "Vous parlez maintenant à {persona}.",
+    "Vous parlez maintenant avec {persona}.",
     "{persona} est désormais en ligne.",
     "{persona} est opérationnelle."
   ],
@@ -40,7 +40,7 @@
   ],
   "persona_select.dialog": [
     "Quelle personnalité voulez-vous activer ?",
-    "Avec quelle personnalité voulez-vous interagir ?",
+    "Avec quelle personnalité voulez-vous discuter ?",
     "Laquelle voulez-vous utiliser ?"
   ],
   "release_persona.dialog": [
@@ -48,7 +48,7 @@
     "{persona} est maintenant désactivée.",
     "Je n'utilise plus {persona}.",
     "{persona} n'est plus active.",
-    "{persona} a été mise hors tension."
+    "Je ne parle plus avec {persona}."
   ],
   "unknown_persona.dialog": [
     "Je ne connais pas {persona}.",

--- a/translations/fr/intents.json
+++ b/translations/fr/intents.json
@@ -1,38 +1,34 @@
 {
   "active_persona.intent": [
-    "(Quel|Quelle) (persona|personnalité) est (en cours d'exécution|en train de parler|actif|active|activé|activée) (maintenant|en ce moment|)",
-    "(Quel|Quelle) (persona|personnalité) est actuellement (actif|activée|activé|active)",
-    "(à qui|à quel persona|à quelle personnalité) je parle (maintenant|en ce moment|actuellement|)",
-    "(qui|quelle personnalité) est (actif|active)",
-    "(qui|quelle|quel) est (le persona|la personnalité) (actif|active)",
-    "Est-ce que je parle à (un persona|une personnalité)",
-    "Y a-t-il (un persona|une personnalité) (actif|active)",
-    "Parle-moi (du persona|de la personnalité) (actif|active)",
-    "Qui est actuellement (active|activée|actif|activé)",
-    "active (le persona|la personnalité)"
+    "(quel|quelle) (persona|personnalité) est (active|activée) (en ce moment|actuellement|)",
+    "(à qui|avec qui) est-ce que je parle (en ce moment|actuellement|)",
+    "(qui|quelle personnalité) est (active|activée)",
+    "quelle est (la persona|la personnalité) active",
+    "y a-t-il (une persona|une personnalité) active",
+    "parle-moi de (la persona|de la personnalité) active",
+    "qui me répond (en ce moment|actuellement|)"
   ],
   "ask.intent": [
-    "(sonde|demande|interroge|pose la question à) {persona} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}",
-    "(sonde|demande|interroge|pose la question à) {persona} pour connaître son point de vue sur {utterance}",
-    "(sonde|demande|interroge|pose la question à) {persona} (sur|de|à propos de) {utterance}",
-    "(demander|demande) à {persona} (de partager|) son (point de vue|opinion) (à propos de|sur) {utterance}",
-    "(demander|demande) à {persona} {utterance}",
-    "(demander|demande) à {persona} (son|sa|ses|) (analyse|commentaire|impression|interprétation|perception|réaction|point de vue|pensées|compréhension) (sur|de|à propos de) {utterance}",
-    "(demander|demande) à {persona} ce qu'(il|elle) (a à dire|pense) (sur|de|à propos de) {utterance}",
-    "que (pense|dit) {persona} (sur|de|à propos de) {utterance}"
+    "(demande|demander) à {persona} son (avis|point de vue|analyse) sur {utterance}",
+    "(demande|demander) à {persona} ce (qu'il|qu'elle) pense de {utterance}",
+    "(demande|demander) à {persona} ce (qu'il|qu'elle) a à dire sur {utterance}",
+    "(demande|demander) à {persona} de réagir à {utterance}",
+    "(interroge|interroger|questionne|questionner) {persona} au sujet de {utterance}",
+    "(pose|poser) une question à {persona} au sujet de {utterance}",
+    "que (pense|dit) {persona} de {utterance}"
   ],
   "list_personas.intent": [
-    "Donne-moi une liste de [personas|persona|personnalités|LLM|LLMs|Large Language Models] [disponibles|disponible]",
-    "Parle-moi des (personas|personnalités|LLM|LLMs|Large Language Models) disponibles",
-    "(Quels|Quelles) (personas|personnalités|LLM|LLMs|Large Language Models) (puis-je utiliser|sont disponibles)",
-    "(Qui|Quels|Quelles) sont les [personas|personnalités|LLM|LLMs|Large Language Models] [disponibles]",
-    "(Peux-tu lister|Liste) les (personas|personnalités|LLM|LLMs|Large Language Models) [disponibles]"
+    "donne-moi la liste des (personas|personnalités) [disponibles]",
+    "parle-moi des (personas|personnalités) disponibles",
+    "(quelles|quels) (personas|personnalités) (puis-je utiliser|sont disponibles)",
+    "(qui|quels|quelles) sont les (personas|personnalités) disponibles",
+    "(peux-tu lister|liste) les (personas|personnalités) [disponibles]"
   ],
   "summon.intent": [
-    "(connecte-moi|je veux parler) (à|avec) {persona}",
-    "(activer|active|accéder à|accède à|réveiller|réveille) (le|la) {persona} (virtuel|virtuelle) (IA|bot|persona|personnalité|agent|assistant|assistante|chatbot|)",
-    "(initier|initie|commencer|commence|ouvrir|ouvre) (un|une|) (chat|interaction|communication|conversation|discussion|dialogue) avec {persona}",
-    "(démarrer|démarre|initier|initie|commencer|commence|entrer|entre|établir|établis) (un|une) (discussion|conversation|dialogue) avec {persona}",
-    "[laisse moi] (parler|chatter|interagir|discuter) (avec|à) {persona}"
+    "(connecte-moi|mets-moi en relation|je veux parler) (à|avec) {persona}",
+    "(active|activer|réveille|réveiller|invoque|invoquer) {persona}",
+    "(active|activer|réveille|réveiller) (la|le) {persona} (persona|personnalité|assistant|chatbot|agent|IA|)",
+    "(démarre|démarrer|ouvre|ouvrir|commence|commencer) (une|la) (conversation|discussion|interaction) avec {persona}",
+    "[laisse-moi] (parler|discuter|interagir) (avec|à) {persona}"
   ]
 }

--- a/translations/fr/intents.json
+++ b/translations/fr/intents.json
@@ -12,7 +12,7 @@
     "active (le persona|la personnalité)"
   ],
   "ask.intent": [
-    "(sonde|demande|interroge|pose la question à) {personne} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}",
+    "(sonde|demande|interroge|pose la question à) {persona} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}",
     "(sonde|demande|interroge|pose la question à) {persona} pour connaître son point de vue sur {utterance}",
     "(sonde|demande|interroge|pose la question à) {persona} (sur|de|à propos de) {utterance}",
     "(demander|demande) à {persona} (de partager|) son (point de vue|opinion) (à propos de|sur) {utterance}",

--- a/translations/fr/intents.json
+++ b/translations/fr/intents.json
@@ -9,12 +9,12 @@
     "qui me répond (en ce moment|actuellement|)"
   ],
   "ask.intent": [
-    "(demande|demander) à {persona} son (avis|point de vue|analyse) sur {utterance}",
-    "(demande|demander) à {persona} ce (qu'il|qu'elle) pense de {utterance}",
-    "(demande|demander) à {persona} ce (qu'il|qu'elle) a à dire sur {utterance}",
-    "(demande|demander) à {persona} de réagir à {utterance}",
-    "(interroge|interroger|questionne|questionner) {persona} au sujet de {utterance}",
-    "(pose|poser) une question à {persona} au sujet de {utterance}",
+    "demande à {persona} son (avis|point de vue|analyse) sur {utterance}",
+    "demande à {persona} ce (qu'il|qu'elle) pense de {utterance}",
+    "demande à {persona} ce (qu'il|qu'elle) a à dire sur {utterance}",
+    "demande à {persona} de réagir à {utterance}",
+    "interroge {persona} au sujet de {utterance}",
+    "pose une question à {persona} au sujet de {utterance}",
     "que (pense|dit) {persona} de {utterance}"
   ],
   "list_personas.intent": [
@@ -26,9 +26,9 @@
   ],
   "summon.intent": [
     "(connecte-moi|mets-moi en relation|je veux parler) (à|avec) {persona}",
-    "(active|activer|réveille|réveiller|invoque|invoquer) {persona}",
-    "(active|activer|réveille|réveiller) (la|le) {persona} (persona|personnalité|assistant|chatbot|agent|IA|)",
-    "(démarre|démarrer|ouvre|ouvrir|commence|commencer) (une|la) (conversation|discussion|interaction) avec {persona}",
+    "(active|réveille|invoque) {persona}",
+    "(active|réveille) (la|le) {persona} (persona|personnalité|assistant|chatbot|agent|IA|)",
+    "(démarre|ouvre|commence) (une|la) (conversation|discussion|interaction) avec {persona}",
     "[laisse-moi] (parler|discuter|interagir) (avec|à) {persona}"
   ]
 }

--- a/translations/fr/vocabs.json
+++ b/translations/fr/vocabs.json
@@ -4,7 +4,7 @@
     "demander",
     "interroge",
     "interroger",
-    "pose une question",
+    "pose une question à",
     "questionne",
     "questionner",
     "sollicite l'avis de"
@@ -34,27 +34,24 @@
     "chatbot",
     "grand modèle de langage",
     "persona",
+    "personas",
     "personnalité",
     "personnalités"
   ],
   "Release.voc": [
-    "(finir|finis|fermer|ferme|stop|arrêter|arrête|sortir de|sors de|quitter|quitte|abandonner|abandonne|terminer|termine|interrompre|interromps|désactiver|désactive) [le|la] (chat|chatbot|persona|IA|LLM|Large Language Model|interaction|conversation|discussion|dialogue)",
-    "(retirer|retire|supprimer|supprimer|arrêter|arrête|terminer|termine) (chat|chatbot|persona|IA|LLM|Large Language Model|)",
-    "(désactiver|désactive|éteindre|éteins) (chat|chatbot|persona|IA|LLM|Large Language Model|)",
+    "(désactive|désactiver|arrête|arrêter|quitte|quitter|ferme|fermer|stop) [la|le] (persona|personnalité|chatbot|assistant|IA|interaction|conversation|discussion)",
+    "(arrête|arrêter|stop) (de parler|de répondre|de discuter)",
+    "(mets|mettre) (la persona|la personnalité|le chatbot|l'assistant|l'IA) en veille",
+    "(éteins|éteindre) [la|le] (persona|personnalité|chatbot|assistant|IA)",
+    "tais-toi",
     "au revoir",
-    "assez (parlé|discuté)",
-    "(pars|va) (en hibernation|dormir|dans la tombe)",
-    "au revoir",
-    "(arrêter|arrête) (la|le) (chat|interaction|conversation|discussion|dialogue)",
     "laisse-moi tranquille",
-    "mettre (chatbot|persona|IA|LLM) en sommeil",
-    "(ferme ta bouche|ferme-la)",
-    "(arrêter|arrête) (de discuter|de communiquer|de répondre|de parler)"
+    "assez parlé"
   ],
   "summon.voc": [
-    "(activer|active|réveiller|réveille|invoquer|invoque|appeler|appelle)",
-    "(connecte-moi|je veux parler) (à|avec)",
-    "(démarrer|démarre|initier|initie|commencer|commence|ouvrir|ouvre) (un|une) (chat|discussion|conversation|dialogue)",
-    "[laisse-moi] (parler|chatter|interagir|discuter) (avec|à)"
+    "(active|activer|réveille|réveiller|invoque|invoquer|appelle|appeler)",
+    "(connecte-moi|mets-moi en relation|je veux parler) (à|avec)",
+    "(démarre|démarrer|ouvre|ouvrir|commence|commencer) (une|la) (conversation|discussion|interaction)",
+    "[laisse-moi] (parler|discuter|interagir) (avec|à)"
   ]
 }

--- a/translations/fr/vocabs.json
+++ b/translations/fr/vocabs.json
@@ -1,4 +1,42 @@
 {
+  "ask.voc": [
+    "demande",
+    "demander",
+    "interroge",
+    "interroger",
+    "pose une question",
+    "questionne",
+    "questionner",
+    "sollicite l'avis de"
+  ],
+  "opinion.voc": [
+    "analyse",
+    "avis",
+    "commentaire",
+    "impression",
+    "interprétation",
+    "pensées",
+    "perception",
+    "point de vue",
+    "position",
+    "réaction"
+  ],
+  "persona.voc": [
+    "IA",
+    "IAs",
+    "LLM",
+    "LLMs",
+    "agent",
+    "assistant",
+    "assistant virtuel",
+    "assistante virtuelle",
+    "bot",
+    "chatbot",
+    "grand modèle de langage",
+    "persona",
+    "personnalité",
+    "personnalités"
+  ],
   "Release.voc": [
     "(finir|finis|fermer|ferme|stop|arrêter|arrête|sortir de|sors de|quitter|quitte|abandonner|abandonne|terminer|termine|interrompre|interromps|désactiver|désactive) [le|la] (chat|chatbot|persona|IA|LLM|Large Language Model|interaction|conversation|discussion|dialogue)",
     "(retirer|retire|supprimer|supprimer|arrêter|arrête|terminer|termine) (chat|chatbot|persona|IA|LLM|Large Language Model|)",
@@ -12,5 +50,11 @@
     "mettre (chatbot|persona|IA|LLM) en sommeil",
     "(ferme ta bouche|ferme-la)",
     "(arrêter|arrête) (de discuter|de communiquer|de répondre|de parler)"
+  ],
+  "summon.voc": [
+    "(activer|active|réveiller|réveille|invoquer|invoque|appeler|appelle)",
+    "(connecte-moi|je veux parler) (à|avec)",
+    "(démarrer|démarre|initier|initie|commencer|commence|ouvrir|ouvre) (un|une) (chat|discussion|conversation|dialogue)",
+    "[laisse-moi] (parler|chatter|interagir|discuter) (avec|à)"
   ]
 }


### PR DESCRIPTION
## Summary
- add the missing French persona vocab files for ask, opinion, persona, and summon flows
- fix the broken French  slot reference in the ask intent
- keep the locale and translation snapshot in sync

## Testing
- git diff --check
- python - <<'PY'
import json
json.load(open('translations/fr/intents.json'))
json.load(open('translations/fr/vocabs.json'))
print('json-ok')
PY