### PR TITLE
Change 'persona' to 'system_prompt' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Save this in `~/.config/ovos_persona/llm.json`:
   "ovos-solver-openai-plugin": {
     "api_url": "https://llama.smartgic.io/v1",
     "key": "sk-xxxx",
-    "persona": "helpful, creative, clever, and very friendly."
+    "system_prompt": "helpful, creative, clever, and very friendly."
   }
 }
 ```


### PR DESCRIPTION
solve: `ovos_solver_openai_persona.engines:__init__:123 - WARNING - 'persona' config option is deprecated, use 'system_prompt' instead`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LLM solver configuration example: the `persona` field has been renamed to `system_prompt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->