### PR TITLE
fix: declare pydantic dependency (persona pipeline fails to import without it)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "ovos-workshop>=0.1.0,<9.0.0",
     "ovos-bus-client>=1.0.0,<3.0.0",
     "ovos-config>=0.0.13,<3.0.0",
-    "pydantic",  # required by ovos-plugin-manager agent_tools (imported by the persona pipeline)
+    "pydantic",  # imported at runtime by ovos-plugin-manager agent_tools (only a test-extra there)
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "ovos-workshop>=0.1.0,<9.0.0",
     "ovos-bus-client>=1.0.0,<3.0.0",
     "ovos-config>=0.0.13,<3.0.0",
+    "pydantic",  # required by ovos-plugin-manager agent_tools (imported by the persona pipeline)
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
`ovos_plugin_manager.templates.agent_tools` does `from pydantic import BaseModel`, and it's imported transitively by `ovos_plugin_manager.persona` → which `PersonaService` imports. On a clean install pydantic isn't pulled (ovos-plugin-manager doesn't declare it; ovos-openai-plugin lists openai only as a test extra), so the persona **pipeline plugin fails to import** (`No module named 'pydantic'`) and is silently disabled — utterances fall through to `complete_intent_failure` with no `speak`.

Declaring `pydantic` here fixes it. Verified in a clean venv: with the dep, `PersonaService` imports, `find_pipeline_plugins()` lists the persona pipeline, and the full test suite (incl. the ovoscope persona-pipeline e2e) runs for real — **28 passed, no skips**.

Root cause is really in ovos-plugin-manager (it imports pydantic without declaring it) — flagged separately; this is the targeted fix for ovos-persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)