### PR TITLE
fix: ship locale resources in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,23 @@ ovos-persona-pipeline-plugin = "ovos_persona:PersonaService"
 [project.entry-points."opm.agents.memory"]
 ovos-agents-short-term-memory-plugin = "ovos_persona.memory:BasicShortTermMemory"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.dynamic]
 version = { attr = "ovos_persona.version.__version__" }
 
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["ovos_persona*"]
+
+[tool.setuptools.package-data]
+ovos_persona = [
+    "locale/**/*.voc",
+    "locale/**/*.intent",
+    "locale/**/*.dialog",
+    "locale/**/*.entity",
+    "locale/**/*.rx",
+    "locale/**/*.word",
+    "locale/**/*",
+]


### PR DESCRIPTION
The persona pipeline reads its intent samples from `ovos_persona/locale` at runtime. The wheel did not declare that directory as package data, so the published wheel omitted it entirely and the pipeline failed to load with:

```
Failed to load pipeline plugin 'ovos-persona-pipeline-plugin':
[Errno 2] No such file or directory: '.../site-packages/ovos_persona/locale'
```

This adds `include-package-data` and a `[tool.setuptools.package-data]` entry for `ovos_persona/locale`, so the wheel ships the locale resources (342 files verified present in the built wheel).

This unblocks every downstream persona-pipeline e2e test PR, which currently fail because the pipeline never loads.