### PR TITLE
chore: add missing shared CI workflows

### DIFF
--- a/.github/workflows/locale-check.yml
+++ b/.github/workflows/locale-check.yml
@@ -1,0 +1,14 @@
+name: Locale Build Check
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  locale_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/locale-check.yml@dev
+    secrets: inherit
+    with:
+      locale_path: 'ovos_persona/locale'
+      pr_comment: true

--- a/.github/workflows/opm-check.yml
+++ b/.github/workflows/opm-check.yml
@@ -1,0 +1,14 @@
+name: OPM Plugin Check
+
+on:
+  pull_request:
+    branches: [dev, master, main]
+  workflow_dispatch:
+
+jobs:
+  opm_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/opm-check.yml@dev
+    secrets: inherit
+    with:
+      python_version: '3.11'
+      plugin_type: 'auto'


### PR DESCRIPTION
Add missing canonical OpenVoiceOS/gh-automations reusable-workflow callers (`@dev`, `secrets: inherit`): opm-check, locale-check (locale dir `ovos_persona/locale`). All other canonical callers already present.