### PR TITLE
fix: require ovos-plugin-manager>=2.1.0 for opm.* entry points and cap ovos-* deps at next major

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "ovos-plugin-manager>=0.8.3,<3.0.0",
+    "ovos-plugin-manager>=2.3.0a1,<3.0.0",
     "ovos-openai-plugin>=2.0.0,<3.0.0",
     "ovos-solver-failure-plugin",
     "ovos-utils>=0.8.0a1,<1.0.0",
@@ -33,7 +33,7 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
-    "ovoscope",
+    "ovoscope<1.0.0",
     "ovos-solver-failure-plugin",
 ]
 


### PR DESCRIPTION
The `opm.*` entry-point group(s) declared by this package are only recognized by `ovos-plugin-manager>=2.1.0` (canonical in PluginTypes since 2.1.0; `opm.agents.*` since 2.3.0a1). An older plugin-manager queries the legacy entry-point group and silently never discovers the plugin. Also caps all `ovos-*` dependencies at the next major so the latest published versions resolve.