### PR TITLE
feat: pass persona config to the memory plugin

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -55,7 +55,9 @@ class Persona:
                 LOG.warning(f"memory plugin '{memory_plugin}' not available; short-term memory disabled")
             self.memory = None
         else:
-            self.memory = memory_class()
+            # pass the persona's per-plugin config block (keyed by plugin name),
+            # mirroring how solver configs are resolved below
+            self.memory = memory_class(config=self.config.get(memory_plugin) or {})
 
         plugin_order = config.get("handlers") or config.get("solvers") or []
         if not plugin_order:


### PR DESCRIPTION
Instantiate the `AgentContextManager` memory plugin with the persona's per-plugin config block (keyed by the memory plugin name), mirroring how solver configs are resolved. This lets memory plugins (e.g. a RAG context manager) be configured from the persona JSON instead of relying on environment variables.

Unblocks `ovos-openai-rag-memory-plugin` (`PersonaServerRAGMemory`) being configured via `memory_module` + its config block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced memory plugin configuration handling during initialization to properly pass configuration settings to memory plugins instead of initializing them without configuration context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->