### PR TITLE
fix: floor ovos-openai-plugin to opm-2.x prerelease

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "ovos-plugin-manager>=2.3.0a1,<3.0.0",
-    "ovos-openai-plugin>=2.0.0,<3.0.0",
+    "ovos-openai-plugin>=2.0.7a8,<3.0.0",
     "ovos-solver-failure-plugin",
     "ovos-utils>=0.8.0a1,<1.0.0",
     "langcodes",


### PR DESCRIPTION
Stable `ovos-openai-plugin` (2.0.5) caps `ovos-plugin-manager<2.0`; floor at the cap-free prerelease `>=2.0.7a8` so persona (and its consumers like ovos-core[plugins]) resolve under opm/bus-client 2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)