### PR TITLE
fix: lift ovos-workshop cap to <10.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ovos-solver-failure-plugin",
     "ovos-utils>=0.8.0a1,<1.0.0",
     "langcodes",
-    "ovos-workshop>=0.1.0,<9.0.0",
+    "ovos-workshop>=0.1.0,<10.0.0",
     "ovos-bus-client>=1.0.0,<3.0.0",
     "ovos-config>=0.0.13,<3.0.0",
 ]


### PR DESCRIPTION
Lifts the `ovos-workshop` upper bound from `<9.0.0` to `<10.0.0` so the
persona pipeline plugin installs alongside the workshop-9 stack (ovos-core
integration branch + INTENT-4 producer).

This unblocks the OVOS-PERSONA-1 conformance harness
(OpenVoiceOS/ovos-test-harness#7), which currently has to pin
`ovos-persona@fix/workshop-9-compat` instead of `@dev` because `@dev` caps
`ovos-workshop<9` and conflicts with the core integration branch (needs
workshop>=9). Once this merges the harness flips its pin to `@dev`.

No code change — pyproject constraint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)