### PR TITLE
fix: make active persona session-resident via persona_id (PERSONA-1 §3/§5/§6/§7)

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -211,13 +211,23 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
     def get_active_persona(self, message, include_default=True) -> Optional[str]:
         """
         Determine the active persona for the given message/session following priority rules.
-        
-        Checks, in order: an explicitly requested persona in message.data, a session-scoped active persona, the session's default persona (if include_default), and the configured default persona (if include_default).
-        
+
+        Per OVOS-PERSONA-1 §3, the active persona is **session-resident**: it lives
+        in ``session.persona_id`` and is carried unchanged across derivations and
+        utterances of the same session. This method reads that field as the
+        authoritative source. The in-memory ``active_personas`` dict is kept only as
+        a best-effort cache for the single-orchestrator case and is consulted after
+        the session field.
+
+        Checks, in order: an explicitly requested persona in message.data, the
+        session-resident ``persona_id``, the legacy in-memory ``active_personas``
+        cache, and (when include_default) the configured default persona.
+
         Parameters:
             message: The incoming message object containing session/context data.
-            include_default (bool): If True, allow falling back to the session or configured default persona.
-        
+            include_default (bool): If True, allow falling back to the configured
+                default persona.
+
         Returns:
             Optional[str]: The resolved persona name if one is found, `None` otherwise.
         """
@@ -227,16 +237,38 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             persona = self.match_persona(message.data.get("persona"))
             if persona:
                 return persona
-        # check if a persona is active
+        # session-resident persona_id is authoritative (OVOS-PERSONA-1 §3)
+        if sess.persona_id:
+            return sess.persona_id
+        # legacy in-memory cache (single-orchestrator best-effort)
         if sess.session_id in self.active_personas:
             return self.active_personas[sess.session_id]
-        # default persona from Session
-        elif sess.persona_id and include_default:
-            return sess.persona_id
         # default persona from config
-        elif self.default_persona and include_default:
+        if self.default_persona and include_default:
             return self.default_persona
         return None
+
+    @staticmethod
+    def _with_persona_id(sess: Session, persona_id: Optional[str]) -> Session:
+        """
+        Return the session with ``persona_id`` set (summon) or cleared (release).
+
+        OVOS-PERSONA-1 §3/§5/§6: the active persona is session-resident. Summon
+        sets ``session.persona_id``; dismiss clears it (empty string, semantically
+        equivalent to absent per §3). The mutated session is propagated to the
+        orchestrator via ``IntentHandlerMatch.updated_session`` (§7.5), which
+        ovos-core carries forward on the dispatch and all subsequent derivations.
+
+        Parameters:
+            sess (Session): The inbound session resolved from the message.
+            persona_id (Optional[str]): The identity to activate, or ``None`` to
+                clear (dismiss).
+
+        Returns:
+            Session: The same session object with ``persona_id`` updated.
+        """
+        sess.persona_id = persona_id or ""
+        return sess
 
     def match_persona(self, persona: str):
         """
@@ -356,12 +388,16 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         """
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
+        sess = SessionManager.get(message)
         active_persona = self.get_active_persona(message, include_default=False)
         if active_persona and self.voc_match(utterances[0], "Release", lang):
+            # OVOS-PERSONA-1 §6: dismiss clears session.persona_id via
+            # Match.updated_session
             return IntentHandlerMatch(match_type='persona:release',
                                       match_data={"persona": active_persona},
                                       skill_id="persona.openvoiceos",
-                                      utterance=utterances[0])
+                                      utterance=utterances[0],
+                                      updated_session=self._with_persona_id(sess, None))
 
         supported_langs = list(self.intent_matchers.keys())
         closest_lang, distance = closest_match(lang, supported_langs, max_distance=10)
@@ -379,10 +415,17 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 persona = entities.get("persona")
                 query = entities.get("utterance")
                 if name == "summon.intent" and persona: # if persona name not in match, its a misclassification
+                    # OVOS-PERSONA-1 §5: summon sets session.persona_id via
+                    # Match.updated_session so the persona is active for
+                    # subsequent utterances. Only set it when the named persona
+                    # resolves to a loaded identity (§5 unique-identity rule).
+                    resolved = self.match_persona(persona)
                     return IntentHandlerMatch(match_type='persona:summon',
                                               match_data={"persona": persona},
                                               skill_id="persona.openvoiceos",
-                                              utterance=utterances[0])
+                                              utterance=utterances[0],
+                                              updated_session=self._with_persona_id(
+                                                  sess, resolved) if resolved else sess)
                 elif name == "list_personas.intent":
                     return IntentHandlerMatch(match_type='persona:list',
                                               match_data={"lang": lang},
@@ -407,8 +450,15 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                         LOG.debug("Discarding ask.intent, requested persona doesn't match any registered persona")
                         # TODO - consider matching and reprompting user
 
-            # override regular intent parsing, handle utterance until persona is released
+            # OVOS-PERSONA-1 §7.1 route 2: active-persona catch-all. No embedded
+            # command was detected, so consult session.persona_id.
             if active_persona:
+                if active_persona not in self.personas:
+                    # §7.1 MUST: persona_id set to a value this plugin does NOT
+                    # support -> return None (let another stage / fallback handle it)
+                    LOG.debug(f"Unsupported persona_id, declining: {active_persona}")
+                    return None
+                # §7.2: an active, supported persona claims every utterance
                 LOG.debug(f"Persona is active: {active_persona}")
                 return self.match_low(utterances, lang, message)
 
@@ -429,12 +479,15 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         lang = lang or self.lang
         lang = standardize_lang_tag(lang)
 
+        sess = SessionManager.get(message)
         active_persona = self.get_active_persona(message, include_default=False)
         if active_persona and self.voc_match(utterances[0], "Release", lang):
+            # OVOS-PERSONA-1 §6: clear session.persona_id on dismiss
             return IntentHandlerMatch(match_type='persona:release',
                                       match_data={"persona": active_persona},
                                       skill_id="persona.openvoiceos",
-                                      utterance=utterances[0])
+                                      utterance=utterances[0],
+                                      updated_session=self._with_persona_id(sess, None))
 
         supported_langs = list(self.intent_matchers.keys())
         closest_lang, distance = closest_match(lang, supported_langs, max_distance=10)
@@ -474,10 +527,14 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
                 persona = entities.get("persona")
                 query = entities.get("query")
                 if name == "summon.intent" and persona:  # if persona name not in match, its a misclassification
+                    # OVOS-PERSONA-1 §5: summon sets session.persona_id
+                    resolved = self.match_persona(persona)
                     return IntentHandlerMatch(match_type='persona:summon',
                                               match_data={"persona": persona},
                                               skill_id="persona.openvoiceos",
-                                              utterance=utterances[0])
+                                              utterance=utterances[0],
+                                              updated_session=self._with_persona_id(
+                                                  sess, resolved) if resolved else sess)
                 elif name == "ask.intent" and persona:  # if persona name not in match, its a misclassification
                     persona = self.match_persona(persona)
                     if persona and query:  # else its a misclassification
@@ -651,6 +708,10 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
             self.speak_dialog("unknown_persona", {"persona": persona})
         else:
             LOG.info(f"Persona enabled: {persona}")
+            # session-resident state (OVOS-PERSONA-1 §3); the match phase already
+            # set this via updated_session, mirror it here for handler-side
+            # session mutation (§8.2) and keep the legacy cache in sync
+            sess.persona_id = persona
             self.active_personas[sess.session_id] = persona
             self.speak_dialog("activated_persona", {"persona": persona})
 
@@ -672,6 +733,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         sess = SessionManager.get(message)
         LOG.info(f"Releasing Persona: {active_persona}  for session: {sess.session_id}")
         self.speak_dialog("release_persona", {"persona": active_persona})
+        # clear session-resident state (OVOS-PERSONA-1 §6); the match phase already
+        # cleared this via updated_session, mirror it here and drop the legacy cache
+        sess.persona_id = ""
         if sess.session_id in self.active_personas:
             self.active_personas.pop(sess.session_id)
 

--- a/test/test_persona_id_session_resident.py
+++ b/test/test_persona_id_session_resident.py
@@ -1,0 +1,178 @@
+"""Session-resident persona_id tests (OVOS-PERSONA-1 §3/§5/§6/§7).
+
+The active persona is a **session-resident** field (``session.persona_id``),
+not process-local state. Summon MUST set it via ``Match.updated_session`` (§5);
+dismiss MUST clear it (§6); an active, supported ``persona_id`` claims every
+utterance (§7.2); an unsupported ``persona_id`` MUST decline (§7.1).
+
+These drive the real ``PersonaService.match_*`` routing through a FakeBus with
+no network (``ovos-solver-failure-plugin`` only). The suite runs under BOTH the
+legacy (``mycroft.*``) and the spec (``ovos.*``) bus namespaces, since
+``persona_id`` is carried on the serialized session regardless of namespace,
+and asserts that two distinct sessions resolve to independent personas — the
+cross-session collision a process-global active persona would cause.
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session, SessionManager
+from ovos_config.config import Configuration
+from ovos_utils.fakebus import FakeBus
+
+from ovos_persona import PersonaService
+
+
+def _persona_dir(*names):
+    tmpdir = tempfile.mkdtemp()
+    for name in names:
+        with open(os.path.join(tmpdir, f"{name}.json"), "w") as fh:
+            json.dump({"name": name, "solvers": ["ovos-solver-failure-plugin"]}, fh)
+    return tmpdir
+
+
+def _msg(session: Session, msg_type: str = "recognizer_loop:utterance",
+         data: dict = None) -> Message:
+    return Message(msg_type, data or {}, {"session": session.serialize()})
+
+
+@pytest.fixture(scope="module")
+def svc():
+    personas_path = _persona_dir("Alice", "Bob")
+    service = PersonaService(
+        bus=FakeBus(),
+        config={"personas_path": personas_path,
+                "ignore_plugin_personas": True},
+    )
+    assert "Alice" in service.personas and "Bob" in service.personas
+    return service
+
+
+# Run every test under both bus namespaces. persona_id lives on the serialized
+# session, which is namespace-independent, so both must behave identically.
+@pytest.fixture(params=[True, False], ids=["legacy_ns", "spec_ns"], autouse=True)
+def namespace(request, svc):
+    Configuration()["legacy_namespace"] = request.param
+    svc.active_personas.clear()
+    yield request.param
+    Configuration()["legacy_namespace"] = True
+    svc.active_personas.clear()
+
+
+def _session(session_id, persona_id=None, lang="en-US"):
+    sess = Session(session_id)
+    sess.lang = lang
+    if persona_id is not None:
+        sess.persona_id = persona_id
+    return sess
+
+
+# ---------------------------------------------------------------------------
+# §5 summon sets session.persona_id via updated_session
+# ---------------------------------------------------------------------------
+
+class TestSummonSetsSessionPersonaId:
+    def test_summon_sets_persona_id_on_updated_session(self, svc):
+        """§5/§3 MUST: a summon match carries persona_id on updated_session."""
+        sess = _session("s-summon")
+        match = svc.match_high(["summon Alice"], "en-US", _msg(sess))
+        assert match is not None, "summon was not matched"
+        assert match.match_type == "persona:summon"
+        assert match.updated_session is not None
+        assert match.updated_session.persona_id == "Alice"
+
+    def test_summon_unknown_persona_does_not_set(self, svc):
+        """§5 unique-identity: a summon naming an unknown persona leaves
+        persona_id unchanged (here: absent)."""
+        sess = _session("s-summon-unknown")
+        match = svc.match_high(["summon Nonexistent"], "en-US", _msg(sess))
+        # either no match, or a match that did not activate an unknown persona
+        if match is not None and match.match_type == "persona:summon":
+            updated = match.updated_session
+            assert not (updated and updated.persona_id == "Nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# §6 dismiss clears session.persona_id via updated_session
+# ---------------------------------------------------------------------------
+
+class TestReleaseClearsSessionPersonaId:
+    def test_release_clears_preset_persona_id(self, svc):
+        """§6 MUST: with persona_id pre-set, a release clears it via
+        updated_session (empty string == absent per §3)."""
+        sess = _session("s-release", persona_id="Alice")
+        match = svc.match_high(["stop talking to alice"], "en-US", _msg(sess))
+        assert match is not None, "release was not matched"
+        assert match.match_type == "persona:release"
+        assert match.updated_session is not None
+        assert match.updated_session.persona_id in (None, "")
+
+
+# ---------------------------------------------------------------------------
+# §7.1 / §7.2 active-persona catch-all
+# ---------------------------------------------------------------------------
+
+class TestActivePersonaCatchAll:
+    def test_supported_persona_id_claims_neutral(self, svc):
+        """§7.2 MUST: a supported, active persona_id claims a neutral utterance."""
+        sess = _session("s-active", persona_id="Alice")
+        match = svc.match_high(["the sky is blue today"], "en-US", _msg(sess))
+        assert match is not None, "active persona did not claim"
+        assert match.match_type == "persona:query"
+        assert match.match_data.get("persona") == "Alice"
+
+    def test_unset_persona_id_declines_neutral(self, svc):
+        """§4/§7.1 MUST: no persona_id -> neutral utterance is declined."""
+        sess = _session("s-none")
+        match = svc.match_high(["the sky is blue today"], "en-US", _msg(sess))
+        assert match is None, f"persona claimed in no-persona mode: {match}"
+
+    def test_unsupported_persona_id_declines(self, svc):
+        """§7.1 MUST: persona_id set to an unsupported value -> decline (None)."""
+        sess = _session("s-unsup", persona_id="no-such-persona-xyz")
+        match = svc.match_high(["the sky is blue today"], "en-US", _msg(sess))
+        assert match is None, f"persona claimed an unsupported persona_id: {match}"
+
+
+# ---------------------------------------------------------------------------
+# Cross-session independence (the collision a process-global persona causes)
+# ---------------------------------------------------------------------------
+
+class TestTwoSessionsAreIndependent:
+    def test_distinct_sessions_resolve_distinct_personas(self, svc):
+        """Two sessions carrying different session-resident persona_ids resolve
+        independently — neither sees the other's persona."""
+        s1 = _session("collide-1", persona_id="Alice")
+        s2 = _session("collide-2", persona_id="Bob")
+
+        m1 = svc.match_high(["the sky is blue today"], "en-US", _msg(s1))
+        m2 = svc.match_high(["the sky is blue today"], "en-US", _msg(s2))
+
+        assert m1 is not None and m2 is not None
+        assert m1.match_data.get("persona") == "Alice"
+        assert m2.match_data.get("persona") == "Bob"
+
+    def test_get_active_persona_reads_session_field(self, svc):
+        """get_active_persona resolves from the session-resident field, so two
+        sessions never collide even with an empty in-memory cache."""
+        assert svc.active_personas == {}
+        s1 = _session("ga-1", persona_id="Alice")
+        s2 = _session("ga-2", persona_id="Bob")
+        assert svc.get_active_persona(_msg(s1), include_default=False) == "Alice"
+        assert svc.get_active_persona(_msg(s2), include_default=False) == "Bob"
+
+    def test_summon_then_release_roundtrip_on_session(self, svc):
+        """A summon match activates Alice on the session; a release match clears
+        it — both observable on updated_session.persona_id."""
+        sess = _session("rt")
+        summoned = svc.match_high(["summon Alice"], "en-US", _msg(sess))
+        assert summoned.updated_session.persona_id == "Alice"
+
+        # carry the activated session forward, then release
+        active = _msg(summoned.updated_session)
+        released = svc.match_high(["stop talking to alice"], "en-US", active)
+        assert released is not None and released.match_type == "persona:release"
+        assert released.updated_session.persona_id in (None, "")


### PR DESCRIPTION
Fixes the central OVOS-PERSONA-1 divergence caught by the conformance suite
(OpenVoiceOS/ovos-test-harness#7): the active persona was tracked in a
process-local `active_personas` dict and never written to the **session-resident**
`session.persona_id` field, so the selection was invisible to the dispatched
session and lost across orchestrator restarts / multi-orchestrator deployments.

## Spec basis
PERSONA-1 §3 registers `persona_id` as the session field that identifies the
active persona; §5 says summon MUST set it via `Match.updated_session`; §6 says
dismiss MUST clear it; §7.1 says an active stage MUST decline (`None`) when
`persona_id` is set to an unsupported value.

`ovos-bus-client` already carries `persona_id` as a canonical inherited Session
field (serialize/deserialize round-trip, present since 2.4.0a1 / dev) — **no
SESSION-1 field addition is required**. `IntentHandlerMatch.updated_session`
already exists and ovos-core already serializes it onto the dispatched reply
(`service.py`), so this is the supported propagation channel.

## Changes
- `get_active_persona` reads `session.persona_id` as the authoritative source
  (§3); the in-memory dict remains a best-effort single-orchestrator cache.
- summon matches set `persona_id` on `updated_session` when the named persona
  resolves to a loaded identity (§5); release matches clear it (§6); the
  handlers mirror the mutation on the handler-side session and the cache.
- the active-persona catch-all DECLINES when `session.persona_id` is unsupported
  (§7.1), instead of claiming via query/fallback.

## Tests
`test/test_persona_id_session_resident.py` (18 cases = 9 × both bus namespaces):
summon-sets / release-clears / supported-claims / unsupported-declines, and two
distinct sessions resolving to independent personas (the collision the suite
caught). Green locally alongside the existing session-isolation suite. The
pre-existing `test_e2e_ovoscope.py` failures are environmental (no libfann /
padatious in the test venv) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)