### PR TITLE
Fix French ask intent training

### DIFF
--- a/ovos_persona/locale/fr/ask.intent
+++ b/ovos_persona/locale/fr/ask.intent
@@ -1,7 +1,6 @@
 (demander|demande) à {persona} (de partager|) son (point de vue|opinion) (à propos de|sur) {utterance}
 (demander|demande) à {persona} (son|sa|ses|) (analyse|commentaire|impression|interprétation|perception|réaction|point de vue|pensées|compréhension) (sur|de|à propos de) {utterance}
 (demander|demande) à {persona} ce qu'(il|elle) (a à dire|pense) (sur|de|à propos de) {utterance}
-(demander|demande) à {persona} {utterance}
 (sonde|demande|interroge|pose la question à) {persona} (sur|de|à propos de) {utterance}
 (sonde|demande|interroge|pose la question à) {persona} pour connaître son point de vue sur {utterance}
 (sonde|demande|interroge|pose la question à) {personne} (son|sa|ses) (opinion|pensées|point de vue|interprétation|position|vue) (de|sur|à propos de) {utterance}


### PR DESCRIPTION
Fixes #194

The French ask intent had one broad sample with adjacent slots:

    (demander|demande) à {persona} {utterance}

That breaks matcher training because there is no literal token between the two slots. The other French ask samples already cover the same flow with explicit connectors, so this drops the invalid one.

Checked locally:

- no adjacent slot-only separators in persona intent resources
- persona intent samples load with the installed matcher