### PR TITLE
fix: clear session persona_id by omission and guard empty memory history

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -258,8 +258,9 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         Return the session with ``persona_id`` set (summon) or cleared (release).
 
         OVOS-PERSONA-1 §3/§5/§6: the active persona is session-resident. Summon
-        sets ``session.persona_id``; dismiss clears it (empty string, semantically
-        equivalent to absent per §3). The mutated session is propagated to the
+        sets ``session.persona_id``; dismiss clears it by omission (``None``) —
+        SESSION-1 §2.1/§3.4: an empty value is expressed by omitting the field,
+        never by sending an empty string. The mutated session is propagated to the
         orchestrator via ``IntentHandlerMatch.updated_session`` (§7.5), which
         ovos-core carries forward on the dispatch and all subsequent derivations.
 
@@ -271,7 +272,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         Returns:
             Session: The same session object with ``persona_id`` updated.
         """
-        sess.persona_id = persona_id or ""
+        sess.persona_id = persona_id or None
         return sess
 
     def match_persona(self, persona: str):
@@ -743,7 +744,7 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         self.speak_dialog("release_persona", {"persona": active_persona})
         # clear session-resident state (OVOS-PERSONA-1 §6); the match phase already
         # cleared this via updated_session, mirror it here and drop the legacy cache
-        sess.persona_id = ""
+        sess.persona_id = None
         if sess.session_id in self.active_personas:
             self.active_personas.pop(sess.session_id)
         # OVOS-PERSONA-1 §11: best-effort dismiss broadcast

--- a/ovos_persona/memory.py
+++ b/ovos_persona/memory.py
@@ -75,11 +75,10 @@ class BasicShortTermMemory(AgentContextManager):
             List[AgentMessage]: Messages representing the augmented context.
         """
         message_history = self.get_history(session_id)
-        if message_history:
-            # drop any hanging user messages without a corresponding response
-            # for any non-verbal actions that OVOS may take
-            while message_history[-1].role == MessageRole.USER:
-                message_history.pop()
+        # drop any hanging user messages without a corresponding response
+        # for any non-verbal actions that OVOS may take
+        while message_history and message_history[-1].role == MessageRole.USER:
+            message_history.pop()
 
         if self.system_prompt.strip():
             message_history.insert(0, AgentMessage(role=MessageRole.SYSTEM, content=self.system_prompt.strip()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 test = [
     "pytest",
     "pytest-cov",
+    "pytest-timeout",
     "ovoscope<1.0.0",
     "ovos-solver-failure-plugin",
 ]
@@ -67,3 +68,8 @@ ovos_persona = [
     "locale/**/*.word",
     "locale/**/*",
 ]
+
+[tool.pytest.ini_options]
+# abort a hung test with a full thread dump instead of stalling the whole job
+timeout = 600
+timeout_method = "thread"

--- a/test/test_e2e_ovoscope.py
+++ b/test/test_e2e_ovoscope.py
@@ -125,14 +125,17 @@ class TestPersonaSpeaksThroughPipeline:
         messages = _drive_utterance(mc, sess, "hello there", timeout=30)
 
         msg_types = [m.msg_type for m in messages]
-        speak_msgs = [m for m in messages if m.msg_type == "speak"]
+        speak_msgs = [m for m in messages
+                      if m.msg_type == "ovos.utterance.speak"]
 
         assert speak_msgs, (
-            f"Expected at least one 'speak' message; got msg_types: {msg_types}"
+            f"Expected at least one 'ovos.utterance.speak' message; "
+            f"got msg_types: {msg_types}"
         )
         spoken = speak_msgs[0].data.get("utterance", "")
         assert spoken.strip(), (
-            f"'speak' message had an empty utterance; data={speak_msgs[0].data}"
+            f"'ovos.utterance.speak' message had an empty utterance; "
+            f"data={speak_msgs[0].data}"
         )
 
     def test_speak_message_has_non_empty_utterance(self, mc):
@@ -142,14 +145,14 @@ class TestPersonaSpeaksThroughPipeline:
         messages = _drive_utterance(mc, sess, "what is the meaning of life", timeout=30)
 
         for msg in messages:
-            if msg.msg_type == "speak":
+            if msg.msg_type == "ovos.utterance.speak":
                 assert msg.data.get("utterance", "").strip(), (
                     f"speak message has empty utterance: {msg.data}"
                 )
                 return   # found a non-empty speak — test passes
 
         pytest.fail(
-            f"No 'speak' message found in pipeline output. "
+            f"No 'ovos.utterance.speak' message found in pipeline output. "
             f"Message types received: {[m.msg_type for m in messages]}"
         )
 

--- a/test/test_memory_e2e.py
+++ b/test/test_memory_e2e.py
@@ -67,6 +67,20 @@ def test_hanging_user_message_dropped():
     assert user_msgs[0].content == "corrected question"
 
 
+def test_context_with_only_hanging_user_history():
+    """A history consisting solely of hanging USER messages (no assistant
+    reply persisted yet) must not crash context assembly; the hanging
+    messages are dropped and the current utterance stands alone."""
+    mem = BasicShortTermMemory(config={"max_history": 10})
+    sess = "hang-only-session"
+
+    mem.update_history([_user("unanswered question")], session_id=sess)
+
+    ctx = mem.build_conversation_context("new question", sess)
+    assert [m.content for m in ctx] == ["new question"]
+    assert ctx[-1].role == MessageRole.USER
+
+
 # ---------------------------------------------------------------------------
 # 3. Consecutive assistant merge (exact content)
 # ---------------------------------------------------------------------------

--- a/test/test_persona_id_session_resident.py
+++ b/test/test_persona_id_session_resident.py
@@ -102,13 +102,14 @@ class TestSummonSetsSessionPersonaId:
 class TestReleaseClearsSessionPersonaId:
     def test_release_clears_preset_persona_id(self, svc):
         """§6 MUST: with persona_id pre-set, a release clears it via
-        updated_session (empty string == absent per §3)."""
+        updated_session. SESSION-1 §2.1/§3.4: cleared means omitted (None),
+        never an empty string on the wire."""
         sess = _session("s-release", persona_id="Alice")
         match = svc.match_high(["stop talking to alice"], "en-US", _msg(sess))
         assert match is not None, "release was not matched"
         assert match.match_type == "persona:release"
         assert match.updated_session is not None
-        assert match.updated_session.persona_id in (None, "")
+        assert match.updated_session.persona_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -175,4 +176,4 @@ class TestTwoSessionsAreIndependent:
         active = _msg(summoned.updated_session)
         released = svc.match_high(["stop talking to alice"], "en-US", active)
         assert released is not None and released.match_type == "persona:release"
-        assert released.updated_session.persona_id in (None, "")
+        assert released.updated_session.persona_id is None


### PR DESCRIPTION
## Summary
- Dismissing a persona stored `persona_id=""` on the updated session. Session validation rejects an empty-string `persona_id` (an absent value is expressed by omitting the field), so the next deserialization raised `MalformedSession` and broke every e2e flow that released a persona. Release now clears the field with `None` so it is omitted on the wire.
- `BasicShortTermMemory.build_conversation_context` crashed with `IndexError` when a session's history consisted solely of hanging user messages: the pop loop kept indexing an emptied list. The loop now guards for emptiness; the `persona:query` handler no longer aborts on a first-turn query.
- Pipeline e2e assertions looked for the legacy `speak` topic; natural-language responses exit the pipeline as `ovos.utterance.speak`, so the assertions never matched. Updated the expectations and tightened the release tests to require `persona_id is None` (never `""`).

## Testing
- Full test suite passes locally against current prereleases (ovos-core 2.5.2a1, ovos-bus-client 2.6.5a1, ovos-workshop 9.2.0a1): 68 passed.
- New regression test: context assembly with only hanging user messages in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)