### PR TITLE
fix: resolve locale directories via closest_lang

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -1,6 +1,6 @@
 import json
 import os
-from os.path import join, dirname, expanduser
+from os.path import join, dirname, expanduser, isdir
 from typing import Optional, Dict, List, Union, Iterable
 
 from langcodes import closest_match
@@ -18,11 +18,12 @@ from ovos_plugin_manager.templates.pipeline import ConfidenceMatcherPipeline, In
 from ovos_plugin_manager.agents import load_memory_plugin
 from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.fakebus import FakeBus
-from ovos_utils.lang import standardize_lang_tag, get_language_dir
+from ovos_utils.lang import standardize_lang_tag
 from ovos_utils.list_utils import flatten_list
 from ovos_utils.log import LOG
 from ovos_utils.parse import match_one, MatchStrategy
 from ovos_utils.xdg_utils import xdg_data_home
+from ovos_spec_tools import closest_lang
 from ovos_workshop.app import OVOSAbstractApplication
 
 from ovos_persona.memory import BasicShortTermMemory
@@ -146,7 +147,10 @@ class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):
         langs = set([standardize_lang_tag(l) for l in langs])
         for lang in langs:
             intents[lang] = {}
-            locale_folder = get_language_dir(join(dirname(__file__), "locale"), lang)
+            locale_root = join(dirname(__file__), "locale")
+            match = closest_lang(lang, [d for d in os.listdir(locale_root)
+                                        if isdir(join(locale_root, d))])
+            locale_folder = join(locale_root, match) if match else None
             if locale_folder is not None:
                 for f in os.listdir(locale_folder):
                     path = join(locale_folder, f)

--- a/test/test_locale_resolution.py
+++ b/test/test_locale_resolution.py
@@ -1,0 +1,25 @@
+"""Intent-file locale resolution no longer relies on the deprecated
+``ovos_utils.lang.get_language_dir`` helper."""
+import unittest
+import warnings
+
+import ovos_persona
+from ovos_persona import PersonaService
+
+
+class TestLocaleResolution(unittest.TestCase):
+    def test_deprecated_helper_not_imported(self):
+        self.assertFalse(hasattr(ovos_persona, "get_language_dir"))
+
+    def test_load_resource_files_resolves_locale_without_deprecation(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            intents = PersonaService.load_resource_files()
+        self.assertIn("en-US", intents)
+        self.assertTrue(any(intents["en-US"].values()))
+        self.assertEqual(
+            [w for w in caught if "get_language_dir" in str(w.message)], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`ovos_persona` imported `get_language_dir` from `ovos_utils.lang`, which is deprecated in favour of `closest_lang` from `ovos_spec_tools`.

`load_resource_files` now resolves the locale subdirectory directly: `closest_lang` selects the nearest available `<lang>/` directory name and the path is joined onto it — exactly what the deprecated helper does internally. `ovos-spec-tools` is already a dependency (floored at `>=1.5.0a1`, which carries `closest_lang`), so no floor change is needed.

Adds a regression test asserting the deprecated symbol is gone and `load_resource_files` still resolves the `en-US` locale with no deprecation emitted.