### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,71 @@
 # OVOS-Persona
 
-The **`PersonaPipeline`** brings multi-persona management to OpenVoiceOS (OVOS), enabling interactive conversations with virtual assistants. 🎙️ With personas, you can customize how queries are handled by assigning specific solvers to each persona.  
+`PersonaPipeline` adds multi-persona management to OpenVoiceOS (OVOS). Personas are configurable virtual assistants: each one assigns its own set of solver plugins to answer queries, so you can customize how OVOS handles a conversation.
+
+See [docs/index.md](docs/index.md) for the architecture and API reference.
 
 ---
 
-## 🚀 TLDR - Quick Start
+## Quick Start
 
-- update core and install persona
-    ```bash
-    pip install -U ovos-core>=0.5.1 ovos-persona
-    ```
-- install/update plugins and skills
-    ```bash
-    pip install -U skill-wolfie ovos-skill-wikipedia ovos-skill-wikihow skill-wordnet ovos-openai-plugin
-    ```
-- uninstall chatgpt skill
-    ```bash
-    pip uninstall skill-ovos-fallback-chatgpt
-    ```
-- edit mycroft.conf
-    > ⚠️ don't just copy paste, the `"..."` is a placeholder and invalid. adjust to your existing pipeline config
-    ```json
-    {
-      "intents": {
-          "persona": {
-            "handle_fallback":  true,
-            "default_persona": "Remote Llama",
-            "short-term-memory": true
-          },
-          "pipeline": [
-              "stop_high",
-              "converse",
-              "ocp_high",
-              "padatious_high",
-              "adapt_high",
-              "ovos-persona-pipeline-plugin-high",
-              "ocp_medium",
-              "...",
-              "fallback_medium",
-              "ovos-persona-pipeline-plugin-low",
-              "fallback_low"
-        ]
-      }
-    }
-    ```
-- restart ovos
-- check logs to see persona loading, ensure there are no errors
-    ```bash
-    cat ~/.local/state/mycroft/skills.log | grep persona
-    ```
-- read the intents section below
-- 🎉
-  
----
-
-## ✨ Features
-
-- **🧑‍💻 Multiple Personas**: Manage a list of personas, each with its unique solvers.  
-- **🔄 Dynamic Switching**: Seamlessly switch between personas as needed.  
-- **🧵 Per-session state**: The active persona and conversation memory are tracked **per session**, so concurrent conversations stay isolated.  
-- **🧠 Short-term memory**: A default short-term memory ships with ovos-persona and is **always available** (per-session history); swap it for any `opm.agents.memory` plugin via `memory_module`. See [`docs/memory.md`](docs/memory.md).  
-- **💬 Conversational**: Let personas handle utterances directly for richer interaction.  
-- **🎨 Personalize**: Create your own personas with simple `.json` files.
+1. Update the core and install the plugin:
+   ```bash
+   pip install -U ovos-core>=0.5.1 ovos-persona
+   ```
+2. Install or update the plugins and skills a persona needs:
+   ```bash
+   pip install -U skill-wolfie ovos-skill-wikipedia ovos-skill-wikihow skill-wordnet ovos-openai-plugin
+   ```
+3. Uninstall the ChatGPT fallback skill, since `ovos-persona` replaces it:
+   ```bash
+   pip uninstall skill-ovos-fallback-chatgpt
+   ```
+4. Edit `mycroft.conf`. The `"..."` below is a placeholder for your existing pipeline entries, not literal text.
+   ```json
+   {
+     "intents": {
+         "persona": {
+           "handle_fallback":  true,
+           "default_persona": "Remote Llama",
+           "short-term-memory": true
+         },
+         "pipeline": [
+             "stop_high",
+             "converse",
+             "ocp_high",
+             "padatious_high",
+             "adapt_high",
+             "ovos-persona-pipeline-plugin-high",
+             "ocp_medium",
+             "...",
+             "fallback_medium",
+             "ovos-persona-pipeline-plugin-low",
+             "fallback_low"
+       ]
+     }
+   }
+   ```
+5. Restart OVOS.
+6. Check the logs to confirm the persona loaded without errors:
+   ```bash
+   cat ~/.local/state/mycroft/skills.log | grep persona
+   ```
+7. Read the [Persona Intents](#persona-intents) section for the voice commands.
 
 ---
 
-## 🛠️ Installation
+## Features
+
+- **Multiple personas**: manage a list of personas, each with its own solver plugins.
+- **Dynamic switching**: activate a different persona at any time.
+- **Per-session state**: the active persona and conversation memory are tracked per session, so concurrent conversations stay isolated.
+- **Short-term memory**: a default short-term memory ships with `ovos-persona` and is always available. Swap it for any `opm.agents.memory` plugin through the `memory_module` config key. See [docs/memory.md](docs/memory.md).
+- **Conversational**: personas can handle utterances directly, without a matching skill.
+- **Personalize**: create a persona with a simple `.json` file. See [docs/defining-personas.md](docs/defining-personas.md).
+
+---
+
+## Installation
 
 ```bash
 pip install ovos-persona
@@ -73,81 +73,69 @@ pip install ovos-persona
 
 ---
 
-## 🗣️ Persona Intents
+## Persona Intents
 
-The Persona Service supports a set of core voice intents to manage persona interactions seamlessly. These intents correspond to the **messagebus events** but are designed for **voice-based activation**.  
+The persona service supports voice intents for managing persona interactions. Each intent corresponds to a messagebus event.
 
-These intents provide **out-of-the-box functionality** for controlling the Persona Service, ensuring smooth integration with the conversational pipeline and enhancing user experience.
+### List personas
 
-### **List Personas**
-
-**Example Utterances**:
+Example utterances:
 - "What personas are available?"
 - "Can you list the personas?"
 - "What personas can I use?"
 
-### **Check Active Persona**
+### Check the active persona
 
-**Example Utterances**:
-
+Example utterances:
 - "Who am I talking to right now?"
 - "Is there an active persona?"
 - "Which persona is in use?"
 
-### **Activate a Persona**
+### Activate a persona
 
-**Example Utterances**:
-- "Connect me to {persona}"  
-- "Enable {persona}"  
-- "Awaken the {persona} assistant"  
-- "Start a conversation with {persona}"  
-- "Let me chat with {persona}"  
+Example utterances:
+- "Connect me to {persona}"
+- "Enable {persona}"
+- "Awaken the {persona} assistant"
+- "Start a conversation with {persona}"
+- "Let me chat with {persona}"
 
+### Ask a persona a single question
 
-### **Single-Shot Persona Questions**
+These utterances query a persona directly, without starting an interactive session.
 
-Enables users to query a persona directly without entering an interactive session.  
+Example utterances:
+- "Ask {persona} what they think about {utterance}"
+- "What does {persona} say about {utterance}?"
+- "Query {persona} for insights on {utterance}"
+- "Ask {persona} for their perspective on {utterance}"
 
-**Example Utterances**:
-- "Ask {persona} what they think about {utterance}"  
-- "What does {persona} say about {utterance}?"  
-- "Query {persona} for insights on {utterance}"  
-- "Ask {persona} for their perspective on {utterance}"  
+### Stop the conversation
 
-
-### **Stop Conversation**
-
-**Example Utterances**:
-- "Stop the interaction"  
-- "Terminate persona"  
-- "Deactivate the chatbot"  
-- "Go dormant"  
-- "Enough talking"  
-- "Shut up"  
+Example utterances:
+- "Stop the interaction"
+- "Terminate persona"
+- "Deactivate the chatbot"
+- "Go dormant"
+- "Enough talking"
+- "Shut up"
 
 ---
 
+## Pipeline Configuration
 
-## 📖  Pipeline Configuration
+When a persona is active, you have two options:
+- send every utterance to the persona and ignore all skills, or
+- let high-confidence skills match before the persona does.
 
-When a persona is active you have 2 options:
-- send all utterances to the persona and ignore all skills
-- let high confidence skills match before using persona
+Where you place `"ovos-persona-pipeline-plugin-high"` in the pipeline decides which behavior you get. `"ovos-persona-pipeline-plugin-low"` handles utterances even when no persona is explicitly active.
 
-Where to place `"ovos-persona-pipeline-plugin-high"` in your pipeline depends on the desired outcome
+#### Option 1: send all utterances to the active persona
 
-Additionally, you have `"ovos-persona-pipeline-plugin-low"` to handle utterances even when a persona isnt explicitly active
+With this option, the persona has full control over user utterances. It will most likely fail to perform actions such as playing music, telling the time, or setting alarms. You must explicitly deactivate the persona to use that functionality.
 
+Add the persona pipeline before the `_high` pipeline matchers. The `"..."` below is a placeholder for your existing pipeline entries, not literal text.
 
-##### Option 1: send all utterances to active persona
-
-In this scenario the persona will most likely fail to perform actions like playing music, telling the time and setting alarms. 
-
-You will need to explicitly deactivate a persona to use that functionality, the persona has **full control** over the user utterances
-
-Add the persona pipeline to your mycroft.conf **before** the `_high` pipeline matchers
-
-> ⚠️ don't just copy paste, the `"..."` is a placeholder and invalid. adjust to your existing pipeline config
 ```json
 {
   "intents": {
@@ -165,13 +153,12 @@ Add the persona pipeline to your mycroft.conf **before** the `_high` pipeline ma
 }
 ```
 
-##### Option 2: let high confidence skills match before using persona
+#### Option 2: let high-confidence skills match before using the persona
 
-With this option you still allow skills to trigger even when a persona is active, not all answers are handled by the persona in this case
+With this option, skills can still trigger even when a persona is active, so not every answer comes from the persona.
 
-Add the persona pipeline to your mycroft.conf **after** the `_high` pipeline matchers
+Add the persona pipeline after the `_high` pipeline matchers. The `"..."` below is a placeholder for your existing pipeline entries, not literal text.
 
-> ⚠️ don't just copy paste, the `"..."` is a placeholder and invalid. adjust to your existing pipeline config
 ```json
 {
   "intents": {
@@ -190,11 +177,9 @@ Add the persona pipeline to your mycroft.conf **after** the `_high` pipeline mat
 }
 ```
 
-##### Extra Option: as fallback skill
+#### Extra option: as a fallback skill
 
-You can configure ovos-persona to handle utterances when all skills fail even if a persona is not active, this is handled via `"ovos-persona-pipeline-plugin-low"`
-
-> ⚠️ don't just copy paste, the `"..."` is a placeholder and invalid. adjust to your existing pipeline config
+You can configure `ovos-persona` to handle utterances when all skills fail, even if no persona is active. This is handled through `"ovos-persona-pipeline-plugin-low"`. The `"..."` below is a placeholder for your existing pipeline entries, not literal text.
 
 ```json
 {
@@ -213,20 +198,19 @@ You can configure ovos-persona to handle utterances when all skills fail even if
 }
 ```
 
-> ⚠️ `"ovos-persona-pipeline-plugin-low"` is meant to replace [ovos-skill-fallback-chatgpt](https://github.com/OpenVoiceOS/ovos-skill-fallback-chatgpt)
+`"ovos-persona-pipeline-plugin-low"` is meant to replace [OpenVoiceOS/ovos-skill-fallback-chatgpt](https://github.com/OpenVoiceOS/ovos-skill-fallback-chatgpt).
 
 ---
 
-## 🔧 Creating a Persona
+## Creating a Persona
 
-Personas are configured using JSON files. These can be:  
-1️⃣ Provided by **plugins** (e.g., [OpenAI plugin](https://github.com/OpenVoiceOS/ovos-openai-plugin/pull/12)).  
-2️⃣ Created as **user-defined JSON files** in `~/.config/ovos_persona`.  
+Personas are configured with JSON files. A persona can come from:
+1. a plugin (for example, the [OpenVoiceOS/ovos-openai-plugin](https://github.com/OpenVoiceOS/ovos-openai-plugin)), or
+2. a user-defined JSON file in `~/.config/ovos_persona`.
 
-Personas rely on [solver plugins](https://openvoiceos.github.io/ovos-technical-manual/solvers/), which attempt to answer queries in sequence until a response is found.  
+Personas rely on [solver plugins](https://openvoiceos.github.io/ovos-technical-manual/solvers/), which try to answer a query in sequence until one succeeds.
 
-🛠️ **Example:** Using a local OpenAI-compatible server.  
-Save this in `~/.config/ovos_persona/llm.json`:  
+Example: a persona using a local OpenAI-compatible server. Save this as `~/.config/ovos_persona/llm.json`:
 ```json
 {
   "name": "My Local LLM",
@@ -241,9 +225,9 @@ Save this in `~/.config/ovos_persona/llm.json`:
 }
 ```
 
-> 💡 **Tip**: Personas don't have to use LLMs! Even without a GPU, you can leverage simpler solvers.  
+A persona does not need an LLM. Simpler solvers work too, even without a GPU.
 
-🛠️ **Example:** OldSchoolBot:  
+Example: OldSchoolBot, a persona built from non-LLM solvers.
 ```json
 {
   "name": "OldSchoolBot",
@@ -258,28 +242,34 @@ Save this in `~/.config/ovos_persona/llm.json`:
   "ovos-solver-plugin-wolfram-alpha": {"appid": "Y7353-xxxxxx"}
 }
 ```
-**Behavior**:
-- 🌐 Searches online (Wikipedia, Wolfram Alpha, etc.).  
-- 📖 Falls back to offline word lookups via WordNet.  
-- 🤖 Uses local chatbot (RiveScript) for chitchat.  
-- ❌ The "failure" solver ensures errors are gracefully handled and we always get a response.
+Behavior:
+- Searches online sources such as Wikipedia and Wolfram Alpha.
+- Falls back to offline word lookups through WordNet.
+- Uses a local chatbot (RiveScript) for chitchat.
+- The "failure" solver catches errors so the persona always returns a response.
 
 ---
 
-## 📡 HiveMind Integration
+## HiveMind Integration
 
-This project includes a native [hivemind-plugin-manager](https://github.com/JarbasHiveMind/hivemind-plugin-manager) integration, providing seamless interoperability with the HiveMind ecosystem.
+This project includes a native [hivemind-plugin-manager](https://github.com/JarbasHiveMind/hivemind-plugin-manager) integration for interoperability with the HiveMind ecosystem.
 
-- **Agent Protocol**: Provides `hivemind-persona-agent-plugin` allowing to connect satellites directly to a persona
-  
+- **Agent protocol**: [hivemind-persona-agent-plugin](https://github.com/JarbasHiveMind/hivemind-persona-agent-plugin) lets HiveMind satellites connect directly to a persona. See [docs/hivemind.md](docs/hivemind.md).
 
 ---
 
+## Related Projects
 
-## 🤝 Contributing
+- [OpenVoiceOS/ovos-persona-server](https://github.com/OpenVoiceOS/ovos-persona-server) — standalone server for persona-based conversations.
+- [TigreGotico/ovos-persona-marketplace](https://github.com/TigreGotico/ovos-persona-marketplace) — a marketplace for sharing persona configurations.
+- [JarbasHiveMind/hivemind-persona-agent-plugin](https://github.com/JarbasHiveMind/hivemind-persona-agent-plugin) — HiveMind agent protocol plugin for `ovos-persona`.
+- [OpenVoiceOS/ovos-openai-plugin](https://github.com/OpenVoiceOS/ovos-openai-plugin) — OpenAI-compatible solver plugin.
 
-Got ideas or found bugs?  
-Submit an issue or create a pull request to help us improve! 🌟  
+---
+
+## Contributing
+
+Found a bug or have an idea? Open an issue or submit a pull request.
 
 ---
 

--- a/docs/defining-personas.md
+++ b/docs/defining-personas.md
@@ -77,13 +77,13 @@ The `handlers` list may include plugins from any of these entry point groups:
 
 | Entry point group | Example plugin | Description |
 |---|---|---|
-| `opm.solver` | `ovos-question-solver-wikipedia-plugin` | Q&A — answers single questions, no chat history |
+| `opm.solver` | `ovos-question-solver-wikipedia-plugin` | Q&A, answers single questions, no chat history |
 | `opm.solver.chat` | `ovos-solver-openai-plugin` | Chat solver with history support |
 | `opm.agents.chat` | `ovos-agent-llama-plugin` | Full LLM chat engine |
-| `opm.agents.chat.multimodal` | — | Multimodal LLM engine |
-| `opm.agents.retrieval` | — | RAG retrieval engine |
-| `opm.agents.indexer.document` | — | Document indexer for RAG |
-| `opm.agents.indexer.qa` | — | QA indexer for RAG |
+| `opm.agents.chat.multimodal` | none | Multimodal LLM engine |
+| `opm.agents.retrieval` | none | RAG retrieval engine |
+| `opm.agents.indexer.document` | none | Document indexer for RAG |
+| `opm.agents.indexer.qa` | none | QA indexer for RAG |
 
 Plugins are tried in the order listed in `handlers`. The first handler that returns a non-empty response wins.
 
@@ -135,3 +135,6 @@ Install any `opm.agents.memory` plugin and reference it by entry point name:
   }
 }
 ```
+
+---
+[← HiveMind](hivemind.md) · [Home](index.md)

--- a/docs/hivemind.md
+++ b/docs/hivemind.md
@@ -72,3 +72,6 @@ This differs from `PersonaService.handle_persona_query()`, which uses `persona.s
 ## Session Tracking
 
 Per-session history is maintained in `self.sessions: Dict[str, List[Dict]]` as raw `{"role": ..., "content": ...}` dicts (compatible with OpenAI-style APIs), keyed by `session_id`.
+
+---
+[← Memory](memory.md) · [Home](index.md) · [Defining Personas →](defining-personas.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # ovos-persona
 
-`ovos-persona` is a pipeline plugin that routes utterances to named AI "personas" — configurable combinations of LLM, solver, and retrieval plugins that give OVOS alternative response personalities beyond normal intent matching.
+`ovos-persona` is a pipeline plugin that routes utterances to named AI "personas": configurable combinations of LLM, solver, and retrieval plugins. A persona gives OVOS an alternative response personality, beyond normal intent matching.
 
 ---
 
@@ -8,7 +8,7 @@
 
 - **Persona**: a named configuration that specifies an ordered list of utterance handler plugins (LLMs, solvers, RAG engines). Each persona has its own handler priority order and optional short-term memory.
 - **PersonaService**: the pipeline stage that loads all personas, matches persona-management intents (`summon`, `ask`, `list`, `release`), and routes utterances to the active persona.
-- **Active persona**: when a user summons a persona by name, all subsequent utterances in that session are routed directly to it — bypassing the normal intent pipeline — until released.
+- **Active persona**: when a user summons a persona by name, all subsequent utterances in that session are routed directly to it, bypassing the normal intent pipeline, until released.
 - **Default persona**: a fallback persona used when `handle_fallback: true` is set in config, allowing the persona system to act as the last-resort pipeline stage.
 
 ---
@@ -41,11 +41,11 @@ Pipeline (ConfidenceMatcherPipeline)
 
 | Document | Contents |
 |---|---|
-| [persona-service.md](persona-service.md) | `PersonaService` — pipeline integration, intent matching, bus events |
-| [persona.md](persona.md) | `Persona` class — solvers, memory, chat/stream API |
-| [solvers.md](solvers.md) | `QuestionSolversService` — plugin types, ordering, completion |
-| [memory.md](memory.md) | `BasicShortTermMemory` — session history, context building |
-| [hivemind.md](hivemind.md) | `PersonaProtocol` — HiveMind agent integration |
+| [persona-service.md](persona-service.md) | `PersonaService`: pipeline integration, intent matching, bus events |
+| [persona.md](persona.md) | `Persona` class: solvers, memory, chat/stream API |
+| [solvers.md](solvers.md) | `QuestionSolversService`: plugin types, ordering, completion |
+| [memory.md](memory.md) | `BasicShortTermMemory`: session history, context building |
+| [hivemind.md](hivemind.md) | `PersonaProtocol`: HiveMind agent integration |
 | [defining-personas.md](defining-personas.md) | Persona JSON format, file locations, plugin entry points |
 
 ---

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -85,16 +85,20 @@ Install a third-party plugin and set `memory_module` in the persona config to it
 
 ---
 
-## Default plugin & per-session isolation
+## Default plugin and per-session isolation
 
-`BasicShortTermMemory` is **shipped and registered by ovos-persona itself** as the
-entry point `ovos-agents-short-term-memory-plugin` (group `opm.agents.memory`), so a
-default short-term memory is **always available** — no extra package required. Every
-`Persona` loads it automatically unless `memory_module` is set to another plugin (or
-to a falsy value to disable memory). If a configured `memory_module` is unavailable,
-the persona degrades gracefully with memory disabled rather than failing to load.
+`ovos-persona` ships and registers `BasicShortTermMemory` itself, as the entry point
+`ovos-agents-short-term-memory-plugin` in the `opm.agents.memory` group. A default
+short-term memory is therefore always available, with no extra package required.
+Every `Persona` loads it automatically, unless `memory_module` is set to another
+plugin or to a falsy value that disables memory. If a configured `memory_module` is
+unavailable, the persona loads with memory disabled instead of failing to load.
 
-History is **isolated per session**: all storage and retrieval are keyed by
-`session_id` (`session2history[session_id]`), so concurrent conversations on different
-sessions never see each other's context. With per-session active personas, each
-session's turns are recorded against the persona active *for that session*.
+History is isolated per session. All storage and retrieval are keyed by
+`session_id` (`session2history[session_id]`), so concurrent conversations on
+different sessions never see each other's context. With per-session active
+personas, each session's turns are recorded against the persona active for that
+session.
+
+---
+[← Solvers](solvers.md) · [Home](index.md) · [HiveMind →](hivemind.md)

--- a/docs/persona-service.md
+++ b/docs/persona-service.md
@@ -31,9 +31,9 @@ svc.load_personas(personas_path=None)
 
 Two sources are merged, with user files taking priority:
 
-1. **User-defined JSON files** — all `.json` files in `personas_path` (default: `~/.config/ovos_persona/`). If the JSON has a `"name"` field it is used as the persona name; otherwise the filename (without `.json`) is used.
+1. **User-defined JSON files**: all `.json` files in `personas_path` (default: `~/.config/ovos_persona/`). If the JSON has a `"name"` field, it is used as the persona name. Otherwise the filename (without `.json`) is used.
 
-2. **Plugin personas** — discovered via `find_persona_plugins()` (entry point group `opm.persona`). Skipped if `ignore_plugin_personas: true` or if a user file with the same name was already loaded.
+2. **Plugin personas**: discovered through `find_persona_plugins()` (entry point group `opm.persona`). Skipped if `ignore_plugin_personas: true`, or if a user file with the same name was already loaded.
 
 Personas in `persona_blacklist` are silently skipped from both sources.
 
@@ -53,12 +53,12 @@ svc.deregister_persona("MyBot")
 
 Runs the utterance through the language-appropriate padatious/padacioso container. Handles:
 
-- **`summon.intent`** → `persona:summon` — if persona name is in the match entities
-- **`ask.intent`** → `persona:query` — if both persona name and query are present and persona exists
+- **`summon.intent`** → `persona:summon`, if the persona name is in the match entities
+- **`ask.intent`** → `persona:query`, if both the persona name and the query are present and the persona exists
 - **`list_personas.intent`** → `persona:list`
 - **`active_persona.intent`** → `persona:check`
-- Release vocabulary → `persona:release` — if a persona is currently active
-- **Active persona passthrough** — if a persona is active and no management intent matches, delegates to `match_low`
+- Release vocabulary → `persona:release`, if a persona is currently active
+- **Active persona passthrough**: if a persona is active and no management intent matches, delegates to `match_low`
 
 Minimum confidence is controlled by `min_intent_confidence` (default `0.6`).
 
@@ -68,7 +68,7 @@ Adapt-like keyword fallback for when padatious confidence is insufficient. Check
 
 ### `match_low(utterances, lang, message)`
 
-Routes directly to the active persona (or default persona if `handle_fallback: true`). Always returns a match when a persona is available — use as a last-resort stage only.
+Routes directly to the active persona (or default persona if `handle_fallback: true`). Always returns a match when a persona is available. Use it as a last-resort stage only.
 
 ---
 
@@ -147,3 +147,6 @@ All speech output uses `self.speak()` / `self.speak_dialog()` from `OVOSAbstract
 | `no_personas` | No personas are loaded |
 | `list_personas` | Prefix before listing persona names |
 | `persona_error` | Persona failed to produce an answer |
+
+---
+[Home](index.md) · [Persona →](persona.md)

--- a/docs/persona.md
+++ b/docs/persona.md
@@ -94,3 +94,6 @@ Both methods delegate to `QuestionSolversService`, passing `sess.lang` and `sess
 repr(persona)
 # → "Persona(MyChatBot:['ovos-solver-openai-plugin', 'ovos-solver-wolfram-alpha-plugin'])"
 ```
+
+---
+[← PersonaService](persona-service.md) · [Home](index.md) · [Solvers →](solvers.md)

--- a/docs/solvers.md
+++ b/docs/solvers.md
@@ -12,15 +12,15 @@ Manages the ordered pipeline of utterance handler plugins for a `Persona`. Tries
 
 | Entry point group | Base class | Chat history support | Streaming |
 |---|---|---|---|
-| `opm.solver` | `QuestionSolver` | No — last message only | Yes (`stream_utterances`) |
+| `opm.solver` | `QuestionSolver` | No, last message only | Yes (`stream_utterances`) |
 | `opm.solver.chat` | `ChatMessageSolver` | Yes | Yes (`stream_chat_utterances`) |
 | `opm.agents.chat` | `ChatEngine` | Yes | Yes (`stream_sentences`) |
 | `opm.agents.chat.multimodal` | `MultimodalChatEngine` | Yes | Yes (`stream_sentences`) |
-| `opm.agents.retrieval` | `RetrievalEngine` | No — last message only | No |
-| `opm.agents.indexer.document` | `DocumentIndexerEngine` | No — last message only | No |
-| `opm.agents.indexer.qa` | `QAIndexerEngine` | No — last message only | No |
+| `opm.agents.retrieval` | `RetrievalEngine` | No, last message only | No |
+| `opm.agents.indexer.document` | `DocumentIndexerEngine` | No, last message only | No |
+| `opm.agents.indexer.qa` | `QAIndexerEngine` | No, last message only | No |
 
-All plugin types are treated uniformly by `QuestionSolversService` — it dispatches to the appropriate method based on the plugin's class.
+`QuestionSolversService` treats all plugin types the same way. It dispatches to the method that matches the plugin's class.
 
 ---
 
@@ -37,7 +37,7 @@ service = QuestionSolversService(
 
 If `sort_order` is empty, plugins are sorted by their `priority` attribute (lower = tried first).
 
-`stream_completion` stops after the first handler that yields at least one sentence — subsequent handlers are not tried.
+`stream_completion` stops after the first handler that yields at least one sentence. It does not try the remaining handlers.
 
 ---
 
@@ -104,3 +104,6 @@ Each handler plugin is configured by its entry point name inside the persona con
 ```
 
 Handlers not in the persona's `handlers` list are disabled regardless of their `enabled` key. If a handler listed in `handlers` is not installed, `ImportError` is raised during `load_plugins()`.
+
+---
+[← Persona](persona.md) · [Home](index.md) · [Memory →](memory.md)


### PR DESCRIPTION
Rewrites README.md for clarity in Simplified Technical English, keeping every fact, code block, badge, and license section. Adds a related-projects section linking sibling repos in the org, and adds cross-page footer navigation to the docs/*.md reference pages.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the Quick Start, installation, features, persona setup, pipeline configuration, and integration guidance.
  * Clarified persona behavior, memory handling, solver types, intent matching, and plugin configuration.
  * Added consistent navigation links across documentation pages.
  * Improved formatting, wording, punctuation, and readability throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->