### PR TITLE
fix: pass lang/units by keyword in Persona.chat and Persona.stream

### DIFF
--- a/ovos_persona/__init__.py
+++ b/ovos_persona/__init__.py
@@ -82,10 +82,16 @@ class Persona:
         return self.memory.build_conversation_context(utterance, sess.session_id)
 
     def chat(self, messages: List[AgentMessage], sess: Session) -> str:
-        return self.solvers.chat_completion(messages, sess.lang, sess.system_unit)
+        return self.solvers.chat_completion(messages,
+                                            session_id=sess.session_id,
+                                            lang=sess.lang,
+                                            units=sess.system_unit)
 
     def stream(self, messages: List[AgentMessage], sess: Session) -> Iterable[str]:
-        return self.solvers.stream_completion(messages, sess.lang, sess.system_unit)
+        return self.solvers.stream_completion(messages,
+                                              session_id=sess.session_id,
+                                              lang=sess.lang,
+                                              units=sess.system_unit)
 
 
 class PersonaService(ConfidenceMatcherPipeline, OVOSAbstractApplication):

--- a/test/test_persona_chat_args.py
+++ b/test/test_persona_chat_args.py
@@ -1,0 +1,87 @@
+"""Regression tests for Persona.chat / Persona.stream argument passthrough.
+
+Persona.chat and Persona.stream forward messages + session data into
+QuestionSolversService.chat_completion / stream_completion, whose signature is
+``(messages, session_id="default", lang=None, units=None)``. Calling that
+method positionally with ``(messages, sess.lang, sess.system_unit)`` shifts
+every argument by one slot: ``sess.lang`` lands in ``session_id`` and
+``sess.system_unit`` lands in ``lang``, while ``units`` is never passed. That
+breaks retrieval-backed personas, whose ``query()`` path uses ``lang`` to
+select the index.
+
+These tests assert the values arrive in the *correct* keyword slots, not just
+that no exception is raised.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ovos_bus_client import Session
+
+from ovos_persona import Persona
+from ovos_persona.solvers import QuestionSolversService
+
+
+class _DummyHandler:
+    """Minimal stand-in utterance handler plugin, never actually invoked in these tests."""
+
+    def __init__(self, config=None):
+        self.config = config or {}
+
+    def shutdown(self):
+        pass
+
+
+def _persona():
+    """Build a Persona with plugin loading stubbed out, then stub its solvers service."""
+    with patch("ovos_persona.solvers.get_utterance_handler_plugins",
+               return_value={"dummy": _DummyHandler}), \
+         patch("ovos_persona.get_utterance_handler_plugins",
+               return_value={"dummy": _DummyHandler}), \
+         patch("ovos_persona.load_memory_plugin", return_value=None):
+        p = Persona(name="test", config={"handlers": ["dummy"]})
+    return p
+
+
+@pytest.fixture
+def sess():
+    s = Session()
+    s.lang = "pt-pt"
+    s.system_unit = "metric"
+    return s
+
+
+def test_chat_passes_lang_and_units_correctly(sess):
+    p = _persona()
+    p.solvers = MagicMock(spec=QuestionSolversService)
+    p.solvers.chat_completion.return_value = "resposta"
+
+    messages = ["hello"]
+    result = p.chat(messages, sess)
+
+    assert result == "resposta"
+    p.solvers.chat_completion.assert_called_once()
+    call = p.solvers.chat_completion.call_args
+    assert call.args[0] == messages
+    assert call.kwargs.get("lang") == "pt-pt"
+    assert call.kwargs.get("units") == "metric"
+    assert call.kwargs.get("lang") != "metric"
+    assert call.kwargs.get("session_id") == sess.session_id
+
+
+def test_stream_passes_lang_and_units_correctly(sess):
+    p = _persona()
+    p.solvers = MagicMock(spec=QuestionSolversService)
+    p.solvers.stream_completion.return_value = iter(["a", "b"])
+
+    messages = ["hello"]
+    result = list(p.stream(messages, sess))
+
+    assert result == ["a", "b"]
+    p.solvers.stream_completion.assert_called_once()
+    call = p.solvers.stream_completion.call_args
+    assert call.args[0] == messages
+    assert call.kwargs.get("lang") == "pt-pt"
+    assert call.kwargs.get("units") == "metric"
+    assert call.kwargs.get("lang") != "metric"
+    assert call.kwargs.get("session_id") == sess.session_id


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Persona.chat and Persona.stream were calling into QuestionSolversService.chat_completion and stream_completion with positional arguments, but the service method takes (messages, session_id="default", lang=None, units=None). The call sites passed (messages, sess.lang, sess.system_unit), which shifts every argument by one slot: the language code lands in session_id, the unit system string lands in lang, and units is never passed at all.

This only shows up for personas backed by a retrieval engine, because that code path uses lang to pick which index to query. When lang actually arrives as "metric" or some other unit string, the retrieval engine chokes and the persona's POST /v1/chat/completions endpoint returns a 500. Chat-engine personas, like the ones backed by the openai plugin, happen to tolerate the wrong lang value well enough that nobody noticed. This was reproduced independently against ovos-wikipedia-plugin and ovos-wolfram-alpha-plugin on the published alphas from 0.9.0a9 through 0.9.0a16.

The fix passes lang, units and session_id by keyword instead of by position, so a future change to the signature can't silently shift arguments again. It also fills in the real sess.session_id instead of leaving the default "default" value, since Session objects always carry one.

I added a regression test, test/test_persona_chat_args.py, that builds a Persona with a mocked solvers service and a Session where lang="pt-pt" and system_unit="metric" are clearly distinguishable, then asserts the mock actually received lang="pt-pt" and units="metric" rather than the swapped values. Running this test against the unfixed code fails with lang landing as None and the raw positional call showing ('pt-pt', 'metric') in the wrong slots; against the fixed code both tests pass. The full suite (uv venv + pip install ".[test]", pytest test) gives 144 passed against my branch versus 142 passed on unmodified dev, with the same 6 pre-existing unrelated failures in test_e2e_ovoscope.py and test_persona_id_session_resident.py present on both, so nothing here regresses them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat and streaming responses by consistently preserving session context, language, and measurement preferences.

- **Tests**
  - Added regression coverage to verify that conversation details are correctly passed through and responses remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->